### PR TITLE
SoE: update balancing

### DIFF
--- a/async_weights.yaml
+++ b/async_weights.yaml
@@ -707,13 +707,13 @@ Super Metroid:
 
   exclude_locations:
     []
-  
+
 Secret of Evermore:
   difficulty: # Changes relative spell cost and stuff
     easy: 0
     normal: 33
     hard: 33
-    chaos: 33
+    mystery: 33
   money_modifier: 150
   exp_modifier: 150
   fix_sequence: true  # Require Leviate for Volcano, Energy Core for Boss Rush
@@ -725,18 +725,18 @@ Secret of Evermore:
   short_boss_rush: false  # Start boss rush at Magmar, cut HP in half
   ingredienizer: # Shuffles or randomizes spell ingredients
     on: 50
-    chaos: 50
+    full: 50
   sniffamizer: # Shuffles or randomizes drops in sniff locations
     on: 50
-    chaos: 50
+    full: 50
   callbeadamizer: # Shuffles call bead characters or spells
     on: 50
-    chaos: 50
+    full: 50
   musicmizer: false  # Randomize music for some rooms
   doggomizer: # On shuffles dog per act, Chaos randomizes dog per screen, Pupdunk gives you Everpupper everywhere
     off: 30
     on: 30
-    chaos: 30
+    full: 30
     pupdunk: 10
   turdo_mode: false  # Replace offensive spells by Turd Balls with varying strength and make weapons weak
-  
+

--- a/async_weights.yaml
+++ b/async_weights.yaml
@@ -714,15 +714,21 @@ Secret of Evermore:
     normal: 33
     hard: 33
     mystery: 33
-  money_modifier: 150
-  exp_modifier: 150
+  money_modifier:
+    150: 75
+    200: 25
+  exp_modifier:
+    150: 75
+    200: 25
   fix_sequence: true  # Require Leviate for Volcano, Energy Core for Boss Rush
   fix_cheats: true  # Fix cheats left in by the devs (not desert skip)
   fix_infinite_ammo: true  # Fix infinite ammo glitch
   fix_atlas_glitch: true  # Fix atlas underflowing stats
   fix_wings_glitch: true  # Fix wings making you invincible in some areas
   shorter_dialogs: true  # Cuts some dialogs
-  short_boss_rush: false  # Start boss rush at Magmar, cut HP in half
+  short_boss_rush:  # Start boss rush at Magmar, cut HP in half
+    on: 50
+    off: 50
   ingredienizer: # Shuffles or randomizes spell ingredients
     on: 50
     full: 50

--- a/async_weights.yaml
+++ b/async_weights.yaml
@@ -746,3 +746,18 @@ Secret of Evermore:
     pupdunk: 10
   turdo_mode: false  # Replace offensive spells by Turd Balls with varying strength and make weapons weak
 
+triggers:
+  # make it less likely to have a hard time with pupdunk
+  - option_category: Secret of Evermore
+    option_name: doggomizer
+    option_result: pupdunk
+    options:
+      Secret of Evermore:
+        difficulty:
+          normal: 50
+          hard: 25
+          mystery: 25
+        exp_modifier:
+          150: 50
+          200: 50
+


### PR DESCRIPTION
This allows to roll some easier seeds.

What's still missing is a trigger for "bad" settings combinations:
I would like to have something like `if doggomizer == "pupdunk" and (difficulty == "hard" or difficulty == "mystery"): wings_glitch = "on"`