### PR TITLE
Don't Force Power Stars to be Local in SM64

### DIFF
--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -23,5 +23,4 @@ Super Mario 64:
   BuddyChecks:
     false: 1
     true: 1
-  local_items:
-    ["Power Star"]
+


### PR DESCRIPTION
It doesn't seem like Figment is going to update their pull request any time soon, so I'll bring this out there again.

This has been discussed and the consensus seems to be that Power Stars in pool will work out better.

If Power Stars are local, the majority of a player's items are going to be in their own world; they will complete all of Floor 1 in their first log-in; and they will be sending very few items into the multiworld. If Power Stars are in the pool, they will log back in multiple times to complete the first floor; and players will be sending out items, allowing them to feel like they are part of the multiworld and not playing a mostly solo game.