### PR TITLE
SA2: Add new options

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -22,7 +22,7 @@ Sonic Adventure 2 Battle:
     beginner: 1
     intermediate: 1
     expert: 3
-  include_chao_karate: # 
+  include_chao_karate:
     false: 2
     true: 1 
   chao_race_checks: all

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -13,3 +13,22 @@ Sonic Adventure 2 Battle:
     "4": 2
     "5": 3
   level_gate_distribution: random
+  required_rank: e
+  level_gate_cost:
+    medium: 1
+    high: 2
+  chao_garden_difficulty:
+    none: 5
+    beginner: 1
+    intermediate: 1
+    expert: 3
+  include_chao_karate: # 
+    false: 2
+    true: 1 
+  chao_race_checks: all
+  junk_fill_percentage: random-low
+  trap_fill_percentage: random-low
+  omochao_trap_weight: random
+  timestop_trap_weight: random
+  confusion_trap_weight: random
+  tiny_trap_weight: random

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -19,9 +19,9 @@ Sonic Adventure 2 Battle:
     high: 2
   chao_garden_difficulty:
     none: 5
-    beginner: 1
+    beginner: 3
     intermediate: 1
-    expert: 3
+    expert: 1
   include_chao_karate:
     false: 2
     true: 1 


### PR DESCRIPTION
I don't feel strongly about the junk fill and trap fill, or whether traps should be included at all; I could see changing random-low to a random-range with lower values as well, but also don't feel particularly strongly about it. Anyone else is free to make that suggestion or change though.

I wanted a 50/50 chance of Chao Garden, with a leaning towards more of it if it gets put in; Chao Karate less so, because it requires the DLC. So including whether Chao Karate is on or off should be expected on the spreadsheet.

Setting rank to E to encourage new players to take these worlds; an experienced player will probably be making a custom. Could still see this change though.