### PR TITLE
SC2 - Difficulty changed to bell curve, more random options, new rele…

### DIFF
--- a/games/Starcraft 2 Wings of Liberty.yaml
+++ b/games/Starcraft 2 Wings of Liberty.yaml
@@ -1,9 +1,9 @@
 Starcraft 2 Wings of Liberty:
   game_difficulty:
-    casual: 2
-    normal: 3
-    hard: 2
-    brutal: 1
+    casual: 20
+    normal: 30
+    hard: 20
+    brutal: 10
   upgrade_bonus:
     ultra_capacitors: 50
     vanadium_plating: 50
@@ -20,7 +20,7 @@ Starcraft 2 Wings of Liberty:
     false: 10
     true: 40
   relegate_no_build:
-    false: 40
-    true: 10
+    false: 50
+    true: 50
   progression_balancing:
     0: 50

--- a/games/Starcraft 2 Wings of Liberty.yaml
+++ b/games/Starcraft 2 Wings of Liberty.yaml
@@ -1,7 +1,9 @@
 Starcraft 2 Wings of Liberty:
   game_difficulty:
-    casual: 50
-    normal: 50
+    casual: 2
+    normal: 3
+    hard: 2
+    brutal: 1
   upgrade_bonus:
     ultra_capacitors: 50
     vanadium_plating: 50
@@ -12,10 +14,13 @@ Starcraft 2 Wings of Liberty:
     ground: 50
     air: 50
   mission_order:
-    vanilla: 40
-    vanilla_shuffled: 10
+    vanilla: 10
+    vanilla_shuffled: 40
   shuffle_protoss:
-    false: 50
-    true: 0
+    false: 10
+    true: 40
+  relegate_no_build:
+    false: 40
+    true: 10
   progression_balancing:
     0: 50


### PR DESCRIPTION
…gate no build option

Game Difficulty:  Client can now alter game difficulty regardless of seed difficulty.  This option was originally added to the client at user request due to the lack of harder difficulty seeds in the previous async.  Now a bell curve centered around Normal difficulty.

Mission Order:  Weights reversed to favor mission shuffle over vanilla for increased randomization.

Shuffle Protoss:  Weighted in favor of shuffling for increased randomization.

Relegate No Build:  New option that moves no-build missions into endgame.  These missions have no logical requirements, so moving them to endgame reduces the likelihood of a player being capable of obtaining a very large number of checks very early.  Weighted in favor of not relegating as option is not as overwhelmingly popular as pure mission randomization.

Tested by generating a seed with 100 yamls with these settings and looking through the spoiler log.