### PR TITLE
Update Timespinner

### DIFF
--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -7,19 +7,11 @@ Timespinner:
   StartWithMeyef: true
   QuickSeed: false
   SpecificKeycards: true
-  Inverted:
-    false: 50
-    true: 50
-  GyreArchives:
-    false: 50
-    true: 50
-  Cantoran:
-    false: 50
-    true: 50
+  Inverted: random
+  GyreArchives: random
+  Cantoran: random
   LoreChecks: true
-  BossRando:
-    false: 50
-    true: 50
+  BossRando: random
   BossScaling: true
   DamageRando: off
   ShopFill: default
@@ -29,4 +21,7 @@ Timespinner:
   LootTierDistro: full_random
   ShowBestiary: true
   ShowDrops: true
+  EnterSandman:
+    false: 75
+    true: 25
   DeathLink: false

--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -1,17 +1,32 @@
 Timespinner:
+  accessibility: items
+  local_items: [Timespinner Gear 1, Timespinner Gear 2, Timespinner Gear 3]
   StartWithJewelryBox: true
   DownloadableItems: true
-  FacebookMode: false
-  StartWithMeyef: false
+  EyeSpy: false
+  StartWithMeyef: true
   QuickSeed: false
   SpecificKeycards: true
   Inverted:
-    true: 1
-    false: 1
+    false: 50
+    true: 50
   GyreArchives:
-    true: 1
-    false: 1
-  Cantoran: false
-  DamageRando: false
+    false: 50
+    true: 50
+  Cantoran:
+    false: 50
+    true: 50
   LoreChecks: true
+  BossRando:
+    false: 50
+    true: 50
+  BossScaling: true
+  DamageRando: off
+  ShopFill: default
+  ShopWarpShards: true
+  LootPool: randomized
+  DropRateCategory: randomized
+  LootTierDistro: full_random
+  ShowBestiary: true
+  ShowDrops: true
   DeathLink: false


### PR DESCRIPTION
- Make Gears local items
- Update FacebookMode to new name EyeSpy
- Change StartWithMeyef to true (you get Meyef as soon as you die for the first time anyway)
- Update Inverted and GyreArchives to use random chance
- Change Cantoran from always false to random (with the new collect functionality of Timespinner, getting stuck behind Cantoran is no longer an issue because a player can just start a new save)
- Add BossRando with a random chance
- Update DamageRando option from false to off
- Add ShopFill set to default
- Add ShopWarpShards set to true
- Add LootPool set to randomized
- Add DropRateCategory set to randomized
- Add LootTierDistro set to full_random
- Add ShowBestiary set to true
- Add ShowDrops set to true
- Add EnterSandman with a quarter chance of being true