### PR TITLE
Update SA2 to 0.3.7.

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -50,12 +50,12 @@ Sonic Adventure 2 Battle:
   speed_mission_3: true
   speed_mission_4: true
   speed_mission_5: false
-  mech_mission_count: random-range-1-2
+  mech_mission_count: random-range-1-3
   mech_mission_2: true
   mech_mission_3: true
   mech_mission_4: true
   mech_mission_5: false
-  hunt_mission_count: random-range-1-2
+  hunt_mission_count: random-range-1-3
   hunt_mission_2: true
   hunt_mission_3: true
   hunt_mission_4: false

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -1,6 +1,6 @@
 Sonic Adventure 2 Battle:
   goal: biolizard
-  mission_shuffle: random
+  mission_shuffle: true
   keysanity:
     false: 2
     true: 1

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -1,13 +1,21 @@
 Sonic Adventure 2 Battle:
+  goal: biolizard
+  mission_shuffle: random
+  keysanity:
+    false: 2
+    true: 1
+  whistlesanity:
+    none: 2
+    pipes: 1
+  beetlesanity:
+    false: 2
+    true: 1
   music_shuffle:
     full: 1
     none: 2
     levels: 1
-  include_missions:
-    "3": 2
-    "4": 1
-    "5": 1
   emblem_percentage_for_cannons_core: random-range-50-75
+  required_cannons_core_missions: first
   number_of_level_gates:
     "3": 1
     "4": 2
@@ -32,3 +40,33 @@ Sonic Adventure 2 Battle:
   timestop_trap_weight: random
   confusion_trap_weight: random
   tiny_trap_weight: random
+  gravity_trap_weight: random
+  exposition_trap_weight: random
+  sadx_music: sa2b
+  narrator: random
+  logic_difficulty: standard
+  speed_mission_count: random-range-2-4
+  speed_mission_2: true
+  speed_mission_3: true
+  speed_mission_4: true
+  speed_mission_5: false
+  mech_mission_count: random-range-1-2
+  mech_mission_2: true
+  mech_mission_3: true
+  mech_mission_4: true
+  mech_mission_5: false
+  hunt_mission_count: random-range-1-2
+  hunt_mission_2: true
+  hunt_mission_3: true
+  hunt_mission_4: false
+  hunt_mission_5: false
+  kart_mission_count: random-range-1-2
+  kart_mission_2: true
+  kart_mission_3: false
+  kart_mission_4: false
+  kart_mission_5: false
+  cannons_core_mission_count: 1
+  cannons_core_mission_2: false
+  cannons_core_mission_3: false
+  cannons_core_mission_4: false
+  cannons_core_mission_5: false


### PR DESCRIPTION
My rationale behind these choices:

Chaos Emeralds can be a bit of a slog and Triforce Hunt-adjacent (more so than Emblems are), so let's leave it out.

Chao Keys and Pipes are doable (and there's a good guide out), but let's keep the chance of them lower. Beetles in general are very easy, but keeping the same random weights for consistency.

For level types, a little bit of variety is good. Keeping Chao missions (Mission 3) in the rotation ensures the Mystic Melodies have a chance to be required, and otherwise the missions are not hard. Ring Missions (Mission 2) are typically very easy. Speed/Mech Mission 4s (Timer) are generally interesting and worth having a chance to show up.

Speed Missions randomly have 2-4 missions each because Speed missions are generally the most fun and interesting. If it rolls 2 or 3, it guarantees there will be variety in the mission type seen; if it rolls 4, at least they will be in random order.

All other missions are 1 or 2, with some variety to allow different mission types to be experienced.

Kart Mission 2 are extremely easy and if Mission Count is rolled 1, the chance that people will only have to do Rings and not the normal run would be a relief.