### PR TITLE
SC2 - New options and campaign types

### DIFF
--- a/games/Starcraft 2 Wings of Liberty.yaml
+++ b/games/Starcraft 2 Wings of Liberty.yaml
@@ -8,7 +8,8 @@ Starcraft 2 Wings of Liberty:
   bunker_upgrade: random
   all_in_map: random
   mission_order:
-    vanilla_shuffled: 40
+    vanilla: 10
+    vanilla_shuffled: 30
     grid: 30
     mini_campaign: 30
   shuffle_protoss: random

--- a/games/Starcraft 2 Wings of Liberty.yaml
+++ b/games/Starcraft 2 Wings of Liberty.yaml
@@ -4,23 +4,15 @@ Starcraft 2 Wings of Liberty:
     normal: 30
     hard: 20
     brutal: 10
-  upgrade_bonus:
-    ultra_capacitors: 50
-    vanadium_plating: 50
-  bunker_upgrade:
-    shrike_turret: 50
-    fortified_bunker: 50
-  all_in_map:
-    ground: 50
-    air: 50
+  upgrade_bonus: random
+  bunker_upgrade: random
+  all_in_map: random
   mission_order:
-    vanilla: 10
     vanilla_shuffled: 40
-  shuffle_protoss:
-    false: 10
-    true: 40
-  relegate_no_build:
-    false: 50
-    true: 50
-  progression_balancing:
-    0: 50
+    grid: 30
+    mini_campaign: 30
+  shuffle_protoss: random
+  shuffle_no_build: random
+  early_unit: true
+  required_tactics: standard
+  units_always_have_upgrades: true


### PR DESCRIPTION
Handles the relegate_no_build -> shuffle_no_build renaming, removes the unrandomized mission order from the campaign types, adds the two longest new mission orders, and locks early_unit + required_tactics + units_always_have_upgrades to beginner/async-friendly settings.