### PR TITLE
Changing game weights

### DIFF
--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -6,23 +6,27 @@ requires:
 # Define your game here!
 game:
   A Link to the Past: 80
-  Factorio: 15
-  Minecraft: 30
-  Slay the Spire: 15
-  Risk of Rain 2: 15
-  Subnautica: 5
-  Ocarina of Time: 25
-  Timespinner: 50
-  Secret of Evermore: 15
-  Super Metroid: 30
-  Rogue Legacy: 40
-  Super Mario 64: 20
-  VVVVVV: 20
-  Sonic Adventure 2 Battle: 20
-  Meritous: 10
-  SMZ3: 30
-  Raft: 5
-  Starcraft 2 Wings of Liberty: 30
-  The Witness: 15
-  Donkey Kong Country 3: 20
   Dark Souls III: 15
+  Donkey Kong Country 3: 20
+  Factorio: 15
+  Hollow Knight: 35
+  Meritous: 10
+  Minecraft: 30
+  Ocarina of Time: 30
+  Overcooked 2!: 15
+  Pokemon Red and Blue: 30
+  Raft: 3
+  Risk of Rain 2: 15
+  Rogue Legacy: 30
+  SMZ3: 30
+  Secret of Evermore: 10
+  Slay the Spire: 15
+  Sonic Adventure 2 Battle: 15
+  Starcraft 2 Wings of Liberty: 30
+  Subnautica: 3
+  Super Mario 64: 25
+  Super Mario World: 20
+  Super Metroid: 30
+  The Witness: 15
+  Timespinner: 45
+  VVVVVV: 15


### PR DESCRIPTION
This was my note from the start of the October async: "About 24 hours after start and no Raft, SA2B, or Subnautica seeds claimed. SoE and V6 both have a ton open. SM64 full, SC2, StS, OOT, LttP, HK, MC mostly full." New games were mostly guesses. There are a lot of people with the Pokemon and SMW roles. In order to find a few percents for HK, OOT, and SM64, I took some from TS and RL. I'd be fine if we lowered the LttP number, but those fillers tend to go fast.