### PR TITLE
Add new options to DS3 yaml

### DIFF
--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -14,3 +14,11 @@ Dark Souls III:
   late_basin_of_vows:
     false: 1
     true: 5
+  no_spell_requirements:
+    false: 2
+    true: 3
+  no_equip_load:
+    false: 2
+    true: 3
+  death_link:
+    false: 50


### PR DESCRIPTION
This change adds the new yaml options "No Spell Requirements", "No Equip Load" and "Death Link" to the DS3 filler yaml. Death Link set to off by default.
No Spell Requirements and No Equip Load weights are equal to No Weapon Requirements weights.