### PR TITLE
Add new options to Subnautica filler

### DIFF
--- a/games/Subnautica.yaml
+++ b/games/Subnautica.yaml
@@ -14,3 +14,11 @@ Subnautica:
     stasis: 5
     containment: 2
     either: 2
+  early_seaglide:
+    true: 2
+    false: 1
+  swim_rule:
+    easy: 5
+    normal: 3
+    items_easy: 5
+    items_normal: 2

--- a/games/Subnautica.yaml
+++ b/games/Subnautica.yaml
@@ -19,6 +19,5 @@ Subnautica:
     false: 1
   swim_rule:
     easy: 5
-    normal: 3
+    normal: 4
     items_easy: 5
-    items_normal: 2

--- a/games/Subnautica.yaml
+++ b/games/Subnautica.yaml
@@ -15,7 +15,7 @@ Subnautica:
     containment: 2
     either: 2
   early_seaglide:
-    true: 2
+    true: 3
     false: 1
   swim_rule:
     easy: 5


### PR DESCRIPTION
Adds the new yaml options "Early Seaglide" and "Swim Rule" to the filler yaml. Weights are what I came up with on the spot, may need to be adjusted. Swim Rule has no weights for Hard options since they can require death runs and I therefore consider them too hard for a filler, Easy has higher chances than Normal to ensure beginners picking up a seed have a better time.