### PR TITLE
python helper script: add -O environment var

### DIFF
--- a/helper_tools/async-roller-python.bat
+++ b/helper_tools/async-roller-python.bat
@@ -5,5 +5,5 @@ set /p num_games="Enter number of games to generate: "
 set /p num_players="Enter number of worlds to generate: "
 
 for /L %%i in (1, 1, %num_games%) do (
-    start py Generate.py --spoiler 0 --multi %num_players% --yaml_output %num_players%
+    start py -O Generate.py --spoiler 0 --multi %num_players% --yaml_output %num_players%
 )


### PR DESCRIPTION
This skips a bunch of debug nonsense and also allows the new error box to pop up on failures (if/when that gets merged) this is still an improvement without the latter.