### PR TITLE
Add Adventure

### DIFF
--- a/games/Adventure.yaml
+++ b/games/Adventure.yaml
@@ -1,0 +1,23 @@
+Adventure:
+  dragon_slay_check: true
+  death_link: false
+  bat_logic:
+    cannot_break: 1
+    can_break: 2
+  freeincarnate_max: 17
+  dragon_rando_type:
+    normal: 2
+    shuffle: 1
+  connector_multi_slot: false
+  yorgle_speed: random-range-1-3
+  yorgle_min_speed: 1
+  grundle_speed: random-range-1-3
+  grundle_min_speed: 1
+  rhindle_speed: random-range-2-4
+  rhindle_min_speed: random-range-1-2
+  difficulty_switch_a: hard_with_unlock_item
+  difficulty_switch_b: hard_with_unlock_item
+  start_castle:
+    yellow: 5
+    black: 1
+    white: 1

--- a/games/Adventure.yaml
+++ b/games/Adventure.yaml
@@ -9,15 +9,15 @@ Adventure:
     normal: 2
     shuffle: 1
   connector_multi_slot: false
-  yorgle_speed: random-range-1-3
+  yorgle_speed: random-range-2-3
   yorgle_min_speed: 1
-  grundle_speed: random-range-1-3
+  grundle_speed: random-range-2-3
   grundle_min_speed: 1
-  rhindle_speed: random-range-2-4
+  rhindle_speed: random-range-3-4
   rhindle_min_speed: random-range-1-2
   difficulty_switch_a: hard_with_unlock_item
   difficulty_switch_b: hard_with_unlock_item
   start_castle:
     yellow: 5
-    black: 1
-    white: 1
+    black: 2
+    white: 2

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -6,6 +6,7 @@ requires:
 # Define your game here!
 game:
   A Link to the Past: 80
+  Adventure: 10
   Dark Souls III: 15
   Donkey Kong Country 3: 20
   Factorio: 15


### PR DESCRIPTION
Not much to talk about here. Having the difficulty switches in the pool just adds some variety and interesting items, since there aren't a ton of items here to begin with. Because it's an async, even if the dragon speeds roll higher than vanilla... you have unlimited tries and infinite time to get around them, so it's not unmanageable; and there will be items in the pool to reduce them to their vanilla speeds if needed. Everything else doesn't change too much, just some variety.

I think 10 is a good weight, it's on par with Meritious and Evermore I feel. I almost originally put 5 until I saw how much higher everything else is...