### PR TITLE
Update SA2 to AP 0.4.0

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -10,6 +10,12 @@ Sonic Adventure 2 Battle:
   beetlesanity:
     false: 2
     true: 1
+  omosanity:
+    false: 2
+    true: 1
+  kart_race_checks:
+    none: 2
+    mini: 1
   music_shuffle:
     full: 1
     none: 2
@@ -42,6 +48,10 @@ Sonic Adventure 2 Battle:
   tiny_trap_weight: random
   gravity_trap_weight: random
   exposition_trap_weight: random
+  pong_trap_weight: random
+  ring_loss:
+    classic: 1
+    modern: 1
   sadx_music: sa2b
   narrator: random
   logic_difficulty: standard


### PR DESCRIPTION
Tossing in the chance for Omosanity and Kart Racing at the same chance as everything else. Kart Racing is limited to mini as full can be a slog.