### PR TITLE
Update DS3 filler to new settings format

### DIFF
--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -9,8 +9,15 @@ Dark Souls III:
     false: 2
     true: 3
   randomize_weapons_level:
-    false: 2
-    true: 3
+    all: 5
+    basic: 1
+    epic: 1
+    none: 4
+  randomize_weapons_percentage: random-range-10-100
+  min_levels_in_5: 1
+  max_levels_in_5: 5
+  min_levels_in_10: 1
+  max_levels_in_10: 10
   late_basin_of_vows:
     false: 1
     true: 5
@@ -22,3 +29,9 @@ Dark Souls III:
     true: 3
   death_link:
     false: 50
+  enable_progressive_locations:
+    true: 1
+    false: 3
+  enable_dlc:
+    true: 1
+    false: 24


### PR DESCRIPTION
New options to look over the weights for:
Randomize_weapons_level, randomize-weapons-percentage, min/max_levels, enable_progressive_locations (adds almost 200 locations that can not hold progression items) DLC is off by default since it's not free and not every player has it, but with a very small chance it could still roll one for people who want to try it out.