### PR TITLE
Update Timespinner

### DIFF
--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -24,4 +24,11 @@ Timespinner:
   EnterSandman:
     false: 75
     true: 25
+  DadPercent:
+    false: 75
+    true: 25
+  RisingTides:
+    false: 75
+    true: 25
+  UnchainedKeys: random
   DeathLink: false


### PR DESCRIPTION
Add Dadpercent, RisingTides, and UnchainedKeys.
Leaving out TrapChance should default it to 10% which I feel is fine.