### PR TITLE
Add Wargroove

### DIFF
--- a/games/Wargroove.yaml
+++ b/games/Wargroove.yaml
@@ -1,0 +1,9 @@
+Wargroove:
+  accessibility: items
+  income_boost: 25
+  commander_defense_boost: 2
+  commander_choice: random
+  local_items:
+   - Final Bridges
+   - Final Walls
+   - Final Sickle

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -30,3 +30,4 @@ game:
   The Witness: 15
   Timespinner: 45
   VVVVVV: 15
+  Wargroove: 15


### PR DESCRIPTION
Adding Wargroove to the filler yamls; vanilla settings with the exception of Commander Choice, which is random.  The three goal items are forced local to match the common convention.

Wargroove is fairly niche by AP standards but still easy to pick up as a new player, so it gets a weight of 15 to match Overcooked and VVVVVV.  