### PR TITLE
Changing Game weights, Adding SDV

### DIFF
--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -5,33 +5,34 @@ requires:
 
 # Define your game here!
 game:
-  A Link to the Past: 80
-  Adventure: 10
-  Dark Souls III: 15
-  Donkey Kong Country 3: 20
-  Factorio: 15
-  Hollow Knight: 35
-  Links Awakening DX: 20
-  Meritous: 10
-  Minecraft: 30
-  Ocarina of Time: 30
-  Overcooked! 2: 15
-  Pokemon Red and Blue: 30
-  Raft: 3
-  Risk of Rain 2: 15
-  Rogue Legacy: 30
-  SMZ3: 30
-  Secret of Evermore: 10
-  Slay the Spire: 15
-  Sonic Adventure 2 Battle: 15
-  Starcraft 2 Wings of Liberty: 30
-  Subnautica: 3
-  Super Mario 64: 25
-  Super Mario World: 20
-  Super Metroid: 30
-  The Legend of Zelda: 10
-  The Messenger: 15
-  The Witness: 15
-  Timespinner: 45
-  VVVVVV: 15
-  Wargroove: 15
+  A Link to the Past: 500
+  Adventure: 50
+  Dark Souls III: 100
+  Donkey Kong Country 3: 150
+  Factorio: 150
+  Hollow Knight: 350
+  Links Awakening DX: 200
+  Meritous: 100
+  Minecraft: 300
+  Ocarina of Time: 300
+  Overcooked! 2: 100
+  Pokemon Red and Blue: 200
+  Raft: 30
+  Risk of Rain 2: 150
+  Rogue Legacy: 300
+  SMZ3: 200
+  Secret of Evermore: 75
+  Slay the Spire: 150
+  Sonic Adventure 2 Battle: 150
+  Starcraft 2 Wings of Liberty: 200
+  Stardew Valley: 150
+  Subnautica: 30
+  Super Mario 64: 250
+  Super Mario World: 200
+  Super Metroid: 200
+  The Legend of Zelda: 125
+  The Messenger: 150
+  The Witness: 150
+  Timespinner: 350
+  VVVVVV: 100
+  Wargroove: 150

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -5,34 +5,34 @@ requires:
 
 # Define your game here!
 game:
-  A Link to the Past: 500
-  Adventure: 50
-  Dark Souls III: 100
-  Donkey Kong Country 3: 150
-  Factorio: 150
-  Hollow Knight: 350
-  Links Awakening DX: 200
-  Meritous: 100
-  Minecraft: 300
-  Ocarina of Time: 300
-  Overcooked! 2: 100
-  Pokemon Red and Blue: 200
-  Raft: 30
-  Risk of Rain 2: 150
-  Rogue Legacy: 300
-  SMZ3: 200
-  Secret of Evermore: 75
-  Slay the Spire: 150
-  Sonic Adventure 2 Battle: 150
-  Starcraft 2 Wings of Liberty: 200
-  Stardew Valley: 150
-  Subnautica: 30
-  Super Mario 64: 250
-  Super Mario World: 200
-  Super Metroid: 200
-  The Legend of Zelda: 125
-  The Messenger: 150
-  The Witness: 150
-  Timespinner: 350
-  VVVVVV: 100
-  Wargroove: 150
+  A Link to the Past: 100
+  Adventure: 10
+  Dark Souls III: 20
+  Donkey Kong Country 3: 30
+  Factorio: 30
+  Hollow Knight: 70
+  Links Awakening DX: 40
+  Meritous: 20
+  Minecraft: 60
+  Ocarina of Time: 60
+  Overcooked! 2: 20
+  Pokemon Red and Blue: 40
+  Raft: 6
+  Risk of Rain 2: 30
+  Rogue Legacy: 60
+  SMZ3: 40
+  Secret of Evermore: 15
+  Slay the Spire: 30
+  Sonic Adventure 2 Battle: 30
+  Starcraft 2 Wings of Liberty: 40
+  Stardew Valley: 30
+  Subnautica: 6
+  Super Mario 64: 50
+  Super Mario World: 40
+  Super Metroid: 40
+  The Legend of Zelda: 25
+  The Messenger: 30
+  The Witness: 30
+  Timespinner: 70
+  VVVVVV: 20
+  Wargroove: 30


### PR DESCRIPTION
Here is my comment near the start of the last async: Looking at unclaimed fillers, LttP, DS3, DKC3, OC2, pokemon, SoE, SMZ3, SC2, SM, TS, V6 are candidates to have lower weights with SC2 being the least filled. LttP makes sense because people like to have multiple of those and there are a lot.