### PR TITLE
Add spice to Slay the Spire filler

### DIFF
--- a/games/Slay the Spire.yaml
+++ b/games/Slay the Spire.yaml
@@ -11,6 +11,8 @@ Slay the Spire:
     random: 0
     random-low: 0
     random-high: 0
+    random-range-1-5: 50
+    random-range-6-10: 5
   heart_run: # Whether or not you will need to collect they 3 keys to unlock the final act
     #     and beat the heart to finish the game.
     false: 50


### PR DESCRIPTION
Having only Ascension 0 fillers seems, quite frankle, quite boring and too easy for many players. This PR adds low Ascension levels (1-5) at the same weight as Ascension 0. This ensures there will still be plenty Ascension 0 games remaining. Medium Ascension (6-10) is added at a very low weight to create a few advanced fillers. High Ascensions are still not regarded, as that challenge is something players should submit in their customs if they wish to play it.