### PR TITLE
Update name of option "final act"

### DIFF
--- a/games/Slay the Spire.yaml
+++ b/games/Slay the Spire.yaml
@@ -11,7 +11,7 @@ Slay the Spire:
     random: 0
     random-low: 0
     random-high: 0
-  heart_run: # Whether or not you will need to collect they 3 keys to unlock the final act
+  final_act: # Whether or not you will need to collect they 3 keys to unlock the final act
     #     and beat the heart to finish the game.
     false: 50
     true: 0


### PR DESCRIPTION
Just a name change in the option "heart_run", which has been recently changed to "final_act", but still works the same.

The filler still rolls fine without this change, but it should still be implemented to ensure compatibility in the future.

