### PR TITLE
Update StS yaml to use new character IDs

### DIFF
--- a/games/Slay the Spire.yaml
+++ b/games/Slay the Spire.yaml
@@ -1,9 +1,9 @@
 Slay the Spire:
-  character: # Pick What Character you wish to play with.
-    ironclad: 50
-    silent: 50
-    defect: 50
-    watcher: 50
+  character: # Enter the internal ID of the character to use.
+    the_ironclad: 50
+    the_silent: 50
+    the_defect: 50
+    the_watcher: 50
   ascension: # What Ascension do you wish to play with.
     # you can add additional values between minimum and maximum
     0: 50 # minimum value
@@ -15,5 +15,8 @@ Slay the Spire:
     random-range-6-10: 5
   final_act: # Whether or not you will need to collect they 3 keys to unlock the final act
             # and beat the heart to finish the game.
+    false: 50
+    true: 0
+  downfall:
     false: 50
     true: 0


### PR DESCRIPTION
From the community async, we had a couple seeds that should have been different characters defaulting to The Ironclad.

> async slot 889 claims to be silent, but is actually ironclad when you connect - can anyone else check this? it's definitely possible that my setup is wrong, but I haven't experienced anything like this before

> my seed (Player976) is also ironclad instead of silent?

Looked like the problem was the `character` format changing with a more recent update, this PR updates those to the new format from the current template YAML.