### PR TITLE
The Messenger: adjustments post 0.4.1

### DIFF
--- a/games/The Messenger.yaml
+++ b/games/The Messenger.yaml
@@ -4,11 +4,11 @@ The Messenger:
     - Keys
   goal:
     open_music_box: 80
-    power_seal_hunt: 10
+    power_seal_hunt: 20
   music_box:
     true: 100
-    false: 10
-  percent_seals_required: random
+    false: 30
+  percent_seals_required: random-range-70-90
   total_seals: random-range-20-45
   shuffle_shards:
     true: 50

--- a/games/The Messenger.yaml
+++ b/games/The Messenger.yaml
@@ -1,6 +1,7 @@
 The Messenger:
   local_items:
     - Power Seal
+    - Keys
   goal:
     open_music_box: 80
     power_seal_hunt: 10
@@ -9,3 +10,6 @@ The Messenger:
     false: 10
   percent_seals_required: random
   total_seals: random-range-20-45
+  shuffle_shards:
+    true: 50
+    false: 80


### PR DESCRIPTION
makes the keys local and adds a chance for mega shards to be shuffled. shop shuffle is always enabled, when that gets merged, and the only new option being added with it is plando costs so no additional yaml updates necessary.