### PR TITLE
Add Muse Dash

### DIFF
--- a/games/Muse Dash.yaml
+++ b/games/Muse Dash.yaml
@@ -1,0 +1,18 @@
+﻿Muse Dash:
+  local_items: [Music Sheet]
+  allow_just_as_planned_dlc_songs: false
+  streamer_mode_enabled: false
+  starting_song_count: 5
+  additional_song_count: random-range-high-40-55
+  additional_item_percentage: random-range-75-85
+  song_difficulty_mode:
+    medium: 67
+    hard: 33
+  grade_needed: any
+  music_sheet_count_percentage: 25
+  music_sheet_win_count_percentage: 80
+  available_trap_types: all
+  trap_count_percentage:
+    0: 50
+    random-range-5-15: 50
+  death_link: false

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -14,6 +14,7 @@ game:
   Links Awakening DX: 40
   Meritous: 20
   Minecraft: 60
+  Muse Dash: 20
   Ocarina of Time: 60
   Overcooked! 2: 20
   Pokemon Red and Blue: 40


### PR DESCRIPTION
Adds yaml for the inclusion of Muse Dash as of AP 0.4.2.

Testing: Rolled a complete player yaml version just fine with a bunch of my own yamls and there's nothing unusual/complicated going on in here anyway.