### PR TITLE
Update SA2 to v0.4.3

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -1,6 +1,12 @@
 Sonic Adventure 2 Battle:
-  goal: biolizard
+  goal:
+    biolizard: 3
+    cannons_core_boss_rush: 1
   mission_shuffle: true
+  boss_rush_shuffle:
+    vanilla: 2
+    shuffled: 1
+    chaos: 1
   keysanity:
     false: 2
     true: 1
@@ -48,7 +54,11 @@ Sonic Adventure 2 Battle:
   tiny_trap_weight: random
   gravity_trap_weight: random
   exposition_trap_weight: random
+  ice_trap_weight: random
+  slow_trap_weight: random
+  cutscene_trap_weight: random
   pong_trap_weight: random
+  minigame_trap_difficulty: easy
   ring_loss:
     classic: 1
     modern: 1

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -34,7 +34,7 @@ Sonic Adventure 2 Battle:
     "5": 3
   level_gate_distribution: random
   required_rank: e
-  level_gate_cost:
+  level_gate_costs:
     medium: 1
     high: 2
   chao_garden_difficulty:


### PR DESCRIPTION
Very few changes. Added in the new traps.

Adding a small chance of Cannons Core Boss Rush since it's kind of interesting but not all that different. Boss Rush Shuffle's result only matters if Cannon's Core Boss Rush rolls.

I personally think Animalsanity is rough and wouldn't enable it for a filler.

And as bizarre as enabling Ring Link would be, I think it's probably safer off?

So yeah. That's all. Have fun gamers.