### PR TITLE
Lower Additional Song Count for Muse Dash worlds.

### DIFF
--- a/games/Muse Dash.yaml
+++ b/games/Muse Dash.yaml
@@ -3,7 +3,7 @@ Muse Dash:
   allow_just_as_planned_dlc_songs: false
   streamer_mode_enabled: false
   starting_song_count: 5
-  additional_song_count: random-range-high-40-55
+  additional_song_count: random-range-high-30-40
   additional_item_percentage: random-range-75-85
   song_difficulty_mode:
     medium: 67

--- a/games/Muse Dash.yaml
+++ b/games/Muse Dash.yaml
@@ -3,7 +3,7 @@ Muse Dash:
   allow_just_as_planned_dlc_songs: false
   streamer_mode_enabled: false
   starting_song_count: 5
-  additional_song_count: random-range-high-30-40
+  additional_song_count: random-range-high-25-35
   additional_item_percentage: random-range-75-85
   song_difficulty_mode:
     medium: 67


### PR DESCRIPTION
Due to low song counts of the base game, `hard` actually didn't have enough songs to satisfy the full range. (There are 43 songs available in that difficulty range.) (Medium has 50+)

So this PR is just to nerf the number of selected songs to 31-41 selected songs. (Start + Additional + Goal) Triggers could be used to make Medium's range a bit larger, but opting to keep this simple.

I definitely should have checked this a bit closer the first time round. :(