### PR TITLE
Heavily reduce max science packs in factorio

### DIFF
--- a/games/Factorio.yaml
+++ b/games/Factorio.yaml
@@ -21,7 +21,7 @@ Factorio:
   min_tech_cost:
     1: 50
   max_tech_cost:
-    random-range-low-100-10000: 20
+    random-range-100-1500: 20
   tech_cost_distribution:
     even: 10
     low: 10


### PR DESCRIPTION
While having a filler seed for Factorio in the most recent async I don't have any techs under 500 and I think that is extremely unreasonable for newer players and for even older players considering mine went up to around 5500 packs for one check. While you can leave it in the background that is not as doable with biters and not everyone has a strong enough system to keep it running and play another game.