### PR TITLE
Update Kingdom Hearts 2.yaml

### DIFF
--- a/games/Kingdom Hearts 2.yaml
+++ b/games/Kingdom Hearts 2.yaml
@@ -15,11 +15,13 @@ Kingdom Hearts 2:
   Final_Form_EXP:
     4: 50
   Summon_EXP:
-    4: 50
+    6: 50
   Schmovement:
     level_1: 50
   RandomGrowth:
     0: 50
+  AntiForm:
+    'false': 50
   Promise_Charm:
     'true': 50
   Goal:
@@ -35,21 +37,33 @@ Kingdom Hearts 2:
     3: 50
   Keyblade_Maximum:
     7: 50
+  WeaponSlotStartHint:
+    'false': 50
+  FightLogic:
+    normal: 50
+  FinalFormLogic:
+    no_light_and_darkness: 50
+  AutoFormLogic:
+    'false': 50
+  DonaldGoofyStatsanity:
+    'true': 50
+  FillerItemsLocal:
+    'true': 50
   Visitlocking:
     first_and_second_visit_locking: 50
   RandomVisitLockingItem:
     3: 50
   SuperBosses:
     'false': 50
-  KeybladeAbilities:
-    support: 50
-  BlacklistKeyblade:
-    - Second Chance
-    - Scan
-    - Once More
-    - Aerial Recovery
   Cups:
     no_cups: 50
+  SummonLevelLocationToggle:
+    'true': 50
+  AtlanticaToggle:
+    'false': 50
+    'true': 5
+  CorSkipToggle:
+    'false': 50
   start_inventory: {}
   exclude_locations: []
   priority_locations: []

--- a/games/Kingdom Hearts 2.yaml
+++ b/games/Kingdom Hearts 2.yaml
@@ -40,6 +40,7 @@ Kingdom Hearts 2:
   WeaponSlotStartHint:
     'false': 50
   FightLogic:
+    easy: 10
     normal: 50
   FinalFormLogic:
     no_light_and_darkness: 50
@@ -48,7 +49,7 @@ Kingdom Hearts 2:
   DonaldGoofyStatsanity:
     'true': 50
   FillerItemsLocal:
-    'true': 50
+    'false': 50
   Visitlocking:
     first_and_second_visit_locking: 50
   RandomVisitLockingItem:


### PR DESCRIPTION
Removed options that no longer exists and added new options.
Only thing I'm unsure of is I chose to not hint weapon slot by default because its just makes the hints tab for KH2 kinda bad cause of how many hints you start with but since you don't start with these hints if you hint for something like flare force and it happens to be on a Donald staff that "costs 2 hints". In terms of Sora abilities all useful progression abilities cannot be on Keyblades so I do not see that as a problem. Only things would be Donald and Goofy limits that a player can be "punished because of this decision"