### PR TITLE
Update A Link to the Past.yaml

### DIFF
--- a/games/A Link to the Past.yaml
+++ b/games/A Link to the Past.yaml
@@ -170,7 +170,7 @@ A Link to the Past:
     pP: 1
   # You can add more combos
   ### End of Shop Section ###
-  shuffle_prizes: g
+  shuffle_prizes: general
   start_inventory: {"Pegasus Boots": 1}
   local_items: ["Moon Pearl", "Pegasus Boots"]
   glitch_boots:


### PR DESCRIPTION
Apparently the prize shuffle option changed from single character options to full words, so this PR updates the `g` option to `general` accordingly.