### PR TITLE
The Messenger: add early med to the messenger fillers

### DIFF
--- a/games/The Messenger.yaml
+++ b/games/The Messenger.yaml
@@ -13,3 +13,6 @@ The Messenger:
   shuffle_shards:
     true: 50
     false: 80
+  early_meditation:
+    true: 80
+    false: 40


### PR DESCRIPTION
Some other options were added in 0.4.5 but don't really belong in fillers.