### PR TITLE
Update Super Mario 64 Settings for 0.4.5

### DIFF
--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -4,9 +4,7 @@ Super Mario 64:
     courses_only: 3
     courses_and_secrets_separate: 2
     courses_and_secrets: 1
-  progressive_keys:
-    true: 5
-    false: 2
+  progressive_keys: true
   enable_coin_stars:
     false: 5
     true: 2
@@ -38,7 +36,14 @@ Super Mario 64:
     items: 5
     locations: 2
   buddy_checks: random
-  exclamation_boxes: random
+  ExclamationBoxes: random
   completion_type:
     last_bowser_stage: 5
     all_bowser_stages: 2
+  triggers:
+    - option_category: Super Mario 64
+      option_name: completion_type
+      option_result: all_bowser_stages
+      options:
+        Super Mario 64:
+          progressive_keys: false

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -1,27 +1,44 @@
 Super Mario 64:
-  AreaRandomizer:
+  area_rando:
     off: 5
     courses_only: 3
     courses_and_secrets_separate: 2
     courses_and_secrets: 1
-  ProgressiveKeys: true
-  EnableCoinStars:
+  progressive_keys:
+    true: 5
+    false: 2
+  enable_coin_stars:
     false: 5
     true: 2
-  StrictCapRequirements:
-    true: 50
-  StrictCannonRequirements:
-    true: 50
-  StarsToFinish:
-    50: 1
-    60: 3
-    70: 4
-    80: 2
+  enable_move_rando:
+    true: 2
+    false: 5
+  move_rando_actions:
+    - Triple Jump
+    - Long Jump
+    - Backflip
+    - Side Flip
+    - Wall Kick
+    - Dive
+    - Ground Pound
+    - Kick
+    - Climb
+    - Ledge Grab
+  strict_cap_requirements: true
+  strict_cannon_requirements: true
+  strict_move_requirements: true
+  amount_of_stars: 120
+  first_bowser_star_door_cost: random-middle
+  basement_star_door_cost: random-middle
+  second_floor_star_door_cost: random-middle
+  mips1_cost: random-middle
+  mips2_cost: random-middle
+  stars_to_finish: random-range-middle-42-67
   accessibility:
-    items: 1
-  BuddyChecks:
-    false: 1
-    true: 1
-  ExclamationBoxes:
-    'off': 1
-    1ups_only: 1
+    items: 5
+    locations: 2
+  buddy_checks: random
+  ExclamationBoxes: random
+  completion_type:
+    last_bowser_stage: 5
+    all_bowser_stages: 2

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -38,7 +38,7 @@ Super Mario 64:
     items: 5
     locations: 2
   buddy_checks: random
-  ExclamationBoxes: random
+  exclamation_boxes: random
   completion_type:
     last_bowser_stage: 5
     all_bowser_stages: 2

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -36,7 +36,7 @@ Super Mario 64:
     items: 5
     locations: 2
   buddy_checks: random
-  ExclamationBoxes: random
+  exclamation_boxes: random
   completion_type:
     last_bowser_stage: 5
     all_bowser_stages: 2


### PR DESCRIPTION
NOTE: All weighted options from the previous version that were not evenly distributed have remained the same or are close to equivalent based on how stars are now percentage-based. Also, all weighted options other than `area_rando` utilize the 5-to-2 weights favoring easier and/or preferred settings that were present for weighted options in the prior version.

Notable changes include:
- Addition of Move Randomization as a weighted option. This is an all-or-nothing randomization rather than only some moves being randomized.
- Addition of a weighted option for keys to be progressive or not. This is largely a function of there being the new goal option of `all_bowser_stages` which means non-progressive keys can make basement key be a goal blocker under certain circumstances now. A more ideal solution might be a set of triggers for `all_bowser_stages` vs. `last_bowser_stage` but I'm only just really starting to get into triggers, so I'm not comfortable with setting that up just yet.
- Added randomized star counts for all potential star count options other than `stars_to_finish` (will address that separately). These are all randomized favoring the middle of their respective ranges which roughly correlates to their default values, but will provide a bit of variability.
- `stars_to_finish` has been changed to a `random-range-middle` such that the lower and upper ranges roughly correlate to the previous weighted option maximums and minimums but with the new percentage-based values. Being a middle range random value means it does not exactly match to the weights of the previous version, but being a `random-range` will provide a wider range of variety compared to the four separate values being ten apart from one another from the prior version.
- Assorted formatting changes such as moving single options to be in line with the option name and changing evenly weighted options to simply be random for conciseness.