### PR TITLE
Blasphemous & Castlevania 64 yamls

### DIFF
--- a/games/Blasphemous.yaml
+++ b/games/Blasphemous.yaml
@@ -1,0 +1,36 @@
+Blasphemous:
+  accessibility: 'items'
+  prie_dieu_warp: 'true'
+  skip_cutscenes: 'true'
+  corpse_hints: 'true'
+  difficulty: 'normal'
+  penitence: 'false'
+  starting_location:
+    albero: 10
+    convent: 3
+    knot_of_words: 3
+    rooftops: 1
+  ending: any_ending
+  skip_long_quests: 'false'
+  thorn_shuffle: anywhere
+  dash_shuffle:
+    'true': 2
+    'false': 8
+  wall_climb_shuffle: 
+    'true': 2
+    'false': 8
+  reliquary_shuffle: 'true'
+  boots_of_pleading: 'false'
+  purified_hand: 'false'
+  start_wheel: 'false'
+  skill_randomizer: 'true'
+  enemy_randomizer: disabled
+  enemy_groups: 'true'
+  enemy_scaling: 'true'
+  death_link: 'false'
+  exclude_locations:
+    - "AtTotS: Miriam's gift"
+  local_items:
+    - Embossed Mask of Crescente
+    - Mirrored Mask of Dolphos
+    - Deformed Mask of Orestes

--- a/games/Castlevania 64.yaml
+++ b/games/Castlevania 64.yaml
@@ -1,5 +1,3 @@
-name: Castlevaneon
-game: Castlevania 64
 Castlevania 64:
   accessibility: items
   character_stages: both

--- a/games/Castlevania 64.yaml
+++ b/games/Castlevania 64.yaml
@@ -1,0 +1,65 @@
+name: Castlevaneon
+game: Castlevania 64
+Castlevania 64:
+  accessibility: items
+  character_stages: both
+  stage_shuffle: 'true'
+  starting_stage: random
+  warp_order: seed_stage_order
+  sub_weapon_shuffle: anywhere
+  spare_keys:
+    on: 5
+    chance: 2
+  hard_item_pool: 'false'
+  ice_trap_percentage: 5
+  ice_trap_appearance: major_only
+  special1s_per_warp: 3
+  total_special1s: 36
+  draculas_condition:
+    bosses: 3
+    specials: 4
+  special2s_required: 20
+  total_special2s: 40
+  bosses_required: 14
+  carrie_logic: 'true'
+  hard_logic: 'false'
+  multi_hit_breakables: 'false'
+  empty_breakables: 'true'
+  lizard_locker_items: 'false'
+  shopsanity: 'true'
+  shop_prices:
+    vanilla: 1
+    randomized: 2
+  minimum_gold_price: 2
+  maximum_gold_price: 50
+  post_behemoth_boss: vanilla
+  room_of_clocks_boss: vanilla
+  renon_fight_condition: never
+  vincent_fight_condition: never
+  bad_ending_condition: never
+  increase_item_limit: 'true'
+  nerf_healing_items: 'false'
+  loading_zone_heals: 'true'
+  invisible_items: reveal_all
+  drop_previous_sub_weapon: 'true'
+  permanent_power_ups: 'true'
+  disable_time_restrictions: 'true'
+  skip_gondolas: 'true'
+  skip_waterway_blocks: 'true'
+  countdown: all_locations
+  panther_dash:
+    on: 1
+    off: 2
+  increase_shimmy_speed: 'true'
+  fall_guard: 'true'
+  background_music: randomized
+  map_lighting: randomized
+  cinematic_experience: 'false'
+  window_color_r: 'random'
+  window_color_g: 'random'
+  window_color_b: 'random'
+  window_color_a: 'random'
+  death_link:
+    off: 99
+    explosive: 1
+

--- a/games/Links Awakening DX.yaml
+++ b/games/Links Awakening DX.yaml
@@ -31,6 +31,14 @@ Links Awakening DX:
     original_dungeon: 5
     own_world: 3
     any_world: 2
+  warp_improvements: true
+  additional_warp_points: true
+  shuffle_instruments:
+    original_dungeon: 10
+    own_dungeons: 10
+    own_world: 10
+    any_world: 5
+    vanilla: 50  
   triggers:
     - option_category: Links Awakening DX
       option_name: goal

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -8,7 +8,9 @@ game:
   A Link to the Past: 100
   A Short Hike: 30
   Adventure: 7
+  Blasphemous: 20
   Bumper Stickers: 10
+  Castlevania 64: 10
   Celeste 64: 15
   Dark Souls III: 31
   DLCQuest: 25


### PR DESCRIPTION
Notes for choices on some settings:

# Blasphemous:
- Starting location weights were chosen to try and maintain a mix of difficulty balance and interesting logical implications. There's a few potential starting locations that were excluded here as they're incompatible with dash / climb shuffle, but it might be fun to set up a trigger to adjust the weights depending on what those other settings rolled. Leaving it as is without the triggers for now though.

- Dash and Wall Climb shuffle disabled as they can introduce some unintuitive workarounds using item combinations that a player new to this rando is unlikely to recognize

- Boots of Pleading and Purified Hand of the Nun disabled as they're not part of the base game and would require additional mods to be installed. Simple process to set up and fun items that have interesting logical ramifications, but vanilla players may find their inclusion confusion.

- The 3 masks required to beat the game were kept local. Used the Hollow Knight yaml as a reference here as they function nearly identically.

- Only excluded one location - a set of 5 increasingly difficult platforming challenges, of which a check is only received after completing all 5.

This does mean that some potentially difficult boss fights may be required.


# Castlevania 64:

- Disabled a lot of the game's non-default additional checks, such as 3-hit breakables and lizard locker items as some of them are in absurdly obscure locations that are exceptionally easy to miss.

- Put a healthy amount of additional special1s in the pool (~25%) than required to keep things moving.

- The biggest setting here is the Dracula condition. I based the percentage of crystal2s needed if the condition rolls "Specials" on similar values used in ALttP's and OoT's triforce hunt settings.

Bosses condition was set to 14 as 2 of the game's 16 bosses are locked behind 4 keys (2x Mandragora + 2x Magical Nitro) which could take a long time to obtain in a large async setting. This could potentially be modified to have those 4 items forced locally and the boss count bumped up to 16.

Crystal condition set to off as the 4 keys mentioned above would be hard-required. Again, could be toggled on if those items were potentially forced local.

- QoL settings all toggled on for the most part.

- Prioritized having Panther Dash off in the interest of not confusing a newer rando player with its existence, but it can be a nice QoL, so kept some probability of it occurring.

- The "Death Link: Explosive" setting is too funny to not give just the tiniest bit of chance to have active.