### PR TITLE
Add Yoshi's Island

### DIFF
--- a/games/Yoshi's Island.yaml
+++ b/games/Yoshi's Island.yaml
@@ -1,0 +1,43 @@
+Yoshi's Island:
+  progression_balancing: 50
+  accessibility: items
+  starting_world: 
+    world_1: 50
+    world_2: 10 
+    world_3: 50
+    world_4: 10
+    world_5: 30
+    world_6: 30
+  starting_lives: random
+  goal: random
+  luigi_pieces_required: random-range-30-50
+  luigi_pieces_in_pool: 50
+  extras_enabled: 
+    false: 70
+    true: 10
+  minigame_checks: random
+  split_extras: 'random'
+  split_bonus: 'random'
+  hidden_object_visibility: coins_only
+  add_secretlens: 'random'
+  shuffle_midrings: 
+    false: 80
+    true: 10
+  stage_logic:
+    strict: 70
+    loose: 30
+  item_logic: 'false'
+  disable_autoscroll: 'true'
+  softlock_prevention: 'true'
+  castle_open_condition: random-range-5-11
+  castle_clear_condition: random-range-0-5
+  bowser_door_mode: manual
+  level_shuffle: random
+  boss_shuffle: random
+  yoshi_colors: random
+  yoshi_singularity_color: random
+  baby_mario_sound: random_sound_effect
+  traps_enabled: 'false'
+  trap_percent: 10
+  death_link: 'false'
+game: Yoshi's Island

--- a/games/Yoshi's Island.yaml
+++ b/games/Yoshi's Island.yaml
@@ -40,4 +40,3 @@ Yoshi's Island:
   traps_enabled: 'false'
   trap_percent: 10
   death_link: 'false'
-game: Yoshi's Island

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -57,6 +57,6 @@ game:
   Undertale: 45
   VVVVVV: 12
   Wargroove: 10
+  Yoshi's Island: 25
   Zillion: 7
   Zork Grand Inquisitor: 7
-  Yoshi's Island: 70

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -59,3 +59,4 @@ game:
   Wargroove: 10
   Zillion: 7
   Zork Grand Inquisitor: 7
+  Yoshi's Island: 70


### PR DESCRIPTION
Not sure if this is good enough, tried to keep things interesting but still mostly random, but here's my comments;

shuffle-midrings- Kind of difficult setting, but in my observation a lot of people tend to enjoy it so I left a small chance to still roll it.

starting_world- High chance to get an early world, lower chance to get a late-game world, and very low chance to get a world with little progression (with level shuffle off)

Most other things were set to a random mid-long tier seed.