### PR TITLE
Adjusted Castlevania 64 yaml Settings

### DIFF
--- a/games/Castlevania 64.yaml
+++ b/games/Castlevania 64.yaml
@@ -1,8 +1,14 @@
 Castlevania 64:
   accessibility: items
   character_stages: both
-  stage_shuffle: 'true'
-  starting_stage: random
+  stage_shuffle: 
+    'true': 2
+    'false': 3
+  starting_stage:
+    forest_of_silence: 1
+    villa: 1
+    castle_center: 1
+    random: 1
   warp_order: seed_stage_order
   sub_weapon_shuffle: anywhere
   spare_keys:
@@ -18,8 +24,10 @@ Castlevania 64:
     specials: 4
   special2s_required: 20
   total_special2s: 40
-  bosses_required: 14
-  carrie_logic: 'true'
+  bosses_required: 12
+  carrie_logic:
+    'true': 1
+    'false': 1
   hard_logic: 'false'
   multi_hit_breakables: 'false'
   empty_breakables: 'true'
@@ -40,18 +48,24 @@ Castlevania 64:
   loading_zone_heals: 'true'
   invisible_items: reveal_all
   drop_previous_sub_weapon: 'true'
-  permanent_power_ups: 'true'
+  permanent_power_ups:
+    'true': 2
+    'false': 1
   disable_time_restrictions: 'true'
   skip_gondolas: 'true'
   skip_waterway_blocks: 'true'
   countdown: all_locations
   panther_dash:
     on: 1
-    off: 2
+    off: 1
   increase_shimmy_speed: 'true'
   fall_guard: 'true'
-  background_music: randomized
-  map_lighting: randomized
+  background_music: 
+    normal: 1
+    randomized: 1
+  map_lighting:
+    normal: 1
+    randomized: 1
   cinematic_experience: 'false'
   window_color_r: 'random'
   window_color_g: 'random'
@@ -60,4 +74,3 @@ Castlevania 64:
   death_link:
     off: 99
     explosive: 1
-


### PR DESCRIPTION
Changes discussed with the game's maintainer, @LiquidCat64 on Discord.

- Set a preference on vanilla stage order.
- Added a priority to starting in denser (and easier) starting locations if random stage shuffle is rolled.
- Required boss count lowered from 14 to 12 if `Bosses` is selected as goal.
- Permanent Power-Ups changed from `true` to a 67% chance.
- Music and Fog Color changed from `true` to a 50% chance to be on or off.
- Panther Dash chance increased from 33% to 50%.

Generated ~20 test seeds to ensure each setting rolls properly.