### PR TITLE
Add a filler YAML for Landstalker

### DIFF
--- a/games/Landstalker - The Treasures of King Nole.yaml
+++ b/games/Landstalker - The Treasures of King Nole.yaml
@@ -1,0 +1,25 @@
+﻿Landstalker - The Treasures of King Nole:
+  goal:
+    beat_gola: 10
+    reach_kazalt: 90
+  spawn_region:
+    massan: 50
+    gumi: 20
+  jewel_count: random-range-5-9
+  progressive_armors: true
+  use_record_book: true
+  use_spell_book: true
+  shop_prices_factor: 80
+  combat_difficulty:
+    easy: 70
+    normal: 30
+  teleport_tree_requirements: clear_tibor_and_visit_trees
+  shuffle_trees: false
+  ensure_ekeeke_in_shops: true
+  remove_gumi_boulder: false
+  allow_whistle_usage_behind_trees: true
+  handle_damage_boosting_in_logic: false
+  handle_enemy_jumping_in_logic: false
+  handle_tree_cutting_glitch_in_logic: false
+  hint_count: random-high
+  revive_using_ekeeke: true

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -24,6 +24,7 @@ game:
   Hylics 2: 7
   Kingdom Hearts 2: 55
   Kirby's Dream Land 3: 25
+  Landstalker - The Treasures of King Nole: 10
   Lingo: 10
   Links Awakening DX: 50
   Lufia II Ancient Cave: 10


### PR DESCRIPTION
This adds a filler YAML for Landstalker, and was designed with the general guideline in mind.
It provides a good entry point to the game by providing easy to slightly challenging objectives, with two possible goals:
- a very common (90%) McGuffin hunt 
- a pretty rare (10%) "finish the game" goal which only adds one huge final dungeon after that hunt

All other options were set to lean to the QoL and accessibility side to keep it challenging without being tedious / frustrating.