### PR TITLE
RoR2 progressive stages addition (AP 0.4.6)

### DIFF
--- a/games/Risk of Rain 2.yaml
+++ b/games/Risk of Rain 2.yaml
@@ -13,6 +13,8 @@ Risk of Rain 2:
   start_with_revive: 'true'
   final_stage_death: random
   dlc_sotv: 'false'
+  require_stages: random
+  progressive_stages: random
   item_pickup_step: random-range-low-0-2
   shrine_use_step: 0
   enable_lunar: random


### PR DESCRIPTION
This is for AP version 0.4.6 which from my understanding will be used for the next async.
This adds two options:
* Progressive stages (Which are the stage items but progressive instead of numbered)
* Require stages (Which will allow not needing the stage items)