### PR TITLE
Remove godhome from HK yaml

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -54,7 +54,11 @@ Hollow Knight:
   DifficultSkips: 'false'
   RemoveSpellUpgrades: 'false'
   StartLocation: king's_pass
-  Goal: random
+  Goal:
+    any: 1
+    hollowknight: 1
+    siblings: 1
+    radiance: 1
   WhitePalace: 
     exclude: 5
     kingfragment: 0


### PR DESCRIPTION
Godhome got added in 0.4.6 as a goal, and is very not suitable for a beginner-medium difficulty slot