### PR TITLE
Update Lingo yaml for Pilgrim Update

### DIFF
--- a/games/Lingo.yaml
+++ b/games/Lingo.yaml
@@ -11,12 +11,26 @@ Lingo:
     insanity: 5
   shuffle_panels: random
   shuffle_paintings: random
-  victory_condition: random
+  victory_condition:
+    the_end: 25
+    the_master: 25
+    level_2: 25
+    pilgrimage: 25
   mastery_achievements: random-high
   level_2_requirement: random-range-200-500
   early_color_hallways: true
   trap_percentage: 20
   puzzle_skip_percentage: 20
+  enable_pilgrimage: random
+  pilgrimage_allows_roof_access: random
+  pilgrimage_allows_paintings: random
+  sunwarp_access:
+    normal: 50
+    disabled: 10
+    unlock: 20
+    progressive: 10
+    individual: 10
+  shuffle_sunwarps: random
   triggers:
     - option_name: shuffle_doors
       option_category: Lingo
@@ -46,3 +60,16 @@ Lingo:
       options:
         Lingo:
           trap_percentage: 2
+    - option_name: victory_condition
+      option_category: Lingo
+      option_result: pilgrimage
+      options:
+        Lingo:
+          enable_pilgrimage: true
+    - option_name: sunwarp_access
+      option_category: Lingo
+      option_result: disabled
+      options:
+        Lingo:
+          enable_pilgrimage: false
+          shuffle_sunwarps: false


### PR DESCRIPTION
The new pilgrimage options added in 0.4.6 are now randomized. This makes sure that pilgrimage is actually enabled when pilgrimage is selected as the win condition. There are also a couple of option combinations that are prohibited, so triggers were added to prevent them.