### PR TITLE
TUNIC: Adjust yaml options

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -5,8 +5,8 @@ TUNIC:
   ability_shuffling: 'true'
   shuffle_ladders: 'true'
   entrance_rando:
-    yes: 10
-    no: 90
+    yes: 20
+    no: 80
   fixed_shop: 'false'
   logic_rules: restricted
   fool_traps: off

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -21,6 +21,9 @@ TUNIC:
     anywhere: 50
     10_fairies: 50
   local_items:
+    - Red Questagon
+    - Blue Questagon
+    - Green Questagon
     - Gold Questagon
 
   triggers:


### PR DESCRIPTION
Looking at the fillers in the current async, I don't think there was enough entrance rando, so I'm doubling the rate here.
With the amount of slots, and the amount going unplayed a couple weeks in, I figure there should be more slots for players who have already played Tunic AP, but haven't tried ER yet.

Also, made it so the mcguffins are always local