### PR TITLE
Bomb Rush Cyberfunk: Add template

### DIFF
--- a/games/Bomb Rush Cyberfunk.yaml
+++ b/games/Bomb Rush Cyberfunk.yaml
@@ -1,0 +1,15 @@
+Bomb Rush Cyberfunk:
+  logic: glitchless
+  skip_intro: true
+  skip_dreams: true
+  skip_statue_hands: true
+  total_rep: random-range-1200-1600
+  extra_rep_required: random
+  starting_movestyle: random
+  limited_graffiti: true
+  small_graffiti_uses: combined
+  skip_polo_photos: false
+  dont_save_photos: true
+  score_difficulty: normal
+  damage_multiplier: 1
+  death_link: false


### PR DESCRIPTION
- Logic is glitchless
- QOL features (`skip_intro`, `skip_dreams`, `skip_statue_hands`, `dont_save_photos`) are enabled
- REP is a random range between 1200-1600. At least 960 REP is required to finish the game, so I think this is a reasonable range that can allow some games to be on the longer end and some on the shorter end.
- Extra REP Required increases the REP requirement from 960 to 1000. The locations in the final area of the game end up being meaningless without this option turned on since you can go straight to the ending. I decided to set it to random.
- Starting Movestyle is random. The three movestyles *do* affect the locations you can reach, but only barely.
- Limited Graffiti is true. This option can have a very large impact on the length/complexity of a seed, and is definitely better left on for asyncs.
- Small Graffiti Uses are combined. This is mostly up to preference, but I assume this is the more popular choice by a lot.
- Polo photos are not skipped
- Score difficulty is normal. This option can be changed to whatever the player wants at any time, so it doesn't really matter anyway.
- Damage multiplier is 1 and death link is off. Both of these options can be changed later if someone really wants to