### PR TITLE
Update Muse Dash.yaml

### DIFF
--- a/games/Muse Dash.yaml
+++ b/games/Muse Dash.yaml
@@ -1,8 +1,5 @@
 Muse Dash:
   local_items: [Music Sheet]
-  allow_just_as_planned_dlc_songs:
-    false: 80
-    true: 20
   streamer_mode_enabled: false
   starting_song_count: 5
   additional_song_count: random-range-high-40-55
@@ -12,11 +9,25 @@ Muse Dash:
   grade_needed: any
   music_sheet_count_percentage: 25
   music_sheet_win_count_percentage: 80
-  available_trap_types: all #essentially equivalent to vfx if DLC is off
+  chosen_traps:
+    - Background Freeze Trap
+    - Bad Apple Trap
+    - Chromatic Aberration Trap
+    - Error SFX Trap
+    - Focus Line Trap
+    - Gray Scale Trap
+    - Nyaa SFX Trap
+    - Pixelate Trap
+    - Ripple Trap
+    - Vignette Trap
   trap_count_percentage:
     0: 50
     random-range-5-15: 50
   death_link: false
+  
+  allow_dlc: #custom setting now for trigger due to DLC handling changes in 0.5.0
+    false: 80
+    true: 20
   triggers:
     # Reduce song count if hard difficulty selected due to fewer songs available for base game + hard diff
     - option_category: Muse Dash
@@ -27,8 +38,9 @@ Muse Dash:
           additional_song_count: random-range-25-35
     # Increase song count if DLC on due to massively larger pool
     - option_category: Muse Dash
-      option_name: allow_just_as_planned_dlc_songs
+      option_name: allow_dlc
       option_result: true
       options:
         Muse Dash:
+          +dlc_packs: [Muse Plus]
           additional_song_count: random-range-75-100


### PR DESCRIPTION
AP 0.5.0 included changes to how Muse Dash handled the trap type and main huge DLC options, this updates the filler to match these updates without any functional change to the outcomes.

Tested by generating (including both outcomes to the DLC trigger)