### PR TITLE
Pokemon Emerald: Disallow randomized pokemon types when match trainer levels is on

### DIFF
--- a/games/Pokemon Emerald.yaml
+++ b/games/Pokemon Emerald.yaml
@@ -277,6 +277,21 @@ Pokemon Emerald:
         Pokemon Emerald:
           trainer_party_blacklist: []
 
+    # Disallow randomized pokemon types when match trainer levels is on 
+    - option_category: Pokemon Emerald
+      option_name: match_trainer_levels
+      option_result: additive
+      options:
+        Pokemon Emerald:
+          types: vanilla
+
+    - option_category: Pokemon Emerald
+      option_name: match_trainer_levels
+      option_result: multiplicative
+      options:
+        Pokemon Emerald:
+          types: vanilla
+
     # Set matching trainer levels bonus
     - option_category: Pokemon Emerald
       option_name: match_trainer_levels


### PR DESCRIPTION
Avoids combo of these settings to allow player to at least have the knowledge to compete fairly when levels are matched and if the types are randomized then lack of knowledge can be compensated by out leveling any problems if need be.