### PR TITLE
Update TUNIC yaml with some more varied options

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,14 +1,21 @@
 TUNIC:
+  # column order for the spreadsheet:
+  # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Entrance Rando | Fewer Shops | Laurels Location
+  # if Hexagon Quest is disabled, put a - for Gold Hexagons Required and Percentage of Extra Hexagons since they are not relevant
   sword_progression: 'true'
-  start_with_sword: random
+  start_with_sword:
+    'true': 25
+    'false': 75
   keys_behind_bosses: 'false'
   ability_shuffling: 'true'
   shuffle_ladders: 'true'
   entrance_rando:
     yes: 20
     no: 80
-  fixed_shop: 'false'
-  logic_rules: restricted
+  logic_rules:
+    restricted: 85
+    no_major_glitches: 10
+    unrestricted: 5
   fool_traps: off
   hexagon_quest:
     'true': 50
@@ -38,7 +45,7 @@ TUNIC:
 
     - option_category: TUNIC
       option_name: entrance_rando
-      option_result: yes
+      option_result: 'yes'
       options:
         TUNIC:
           fixed_shop:

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -10,8 +10,8 @@ TUNIC:
   ability_shuffling: 'true'
   shuffle_ladders: 'true'
   entrance_rando:
-    yes: 20
-    no: 80
+    yes: 25
+    no: 75
   logic_rules:
     restricted: 85
     no_major_glitches: 10


### PR DESCRIPTION
- Reduced chance of start with sword
- Varied the logic rules option (both should be doable for most, the tricks aren't particularly hard to pull off mechanically, it's just a matter of learning them)
- Slightly bumped up the chance of entrance rando
- Added some comments regarding what order to put the columns in on the spreadsheet (since we talked about them the last couple times, might as well have it written down somewhere)