### PR TITLE
output usable files for each game and rename mystery.yaml to weights.yaml

### DIFF
--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -107,10 +107,13 @@ def main():
     with open("output/weights.yaml", "w+") as file:
         yaml.dump(dict(mystery), file)
     with open("output/games.yaml", "w+") as file:
-        for game in mystery["game"]:
+        games = list(mystery["game"])
+        last_key = games[-1]
+        for game in games:
             game_options = GameSettings(mystery["name"], mystery["description"], mystery["requires"], game, mystery[game])
             yaml.dump(dict(game_options), file)
-            file.write("\n---\n\n")
+            if not last_key:
+                file.write("\n---\n\n")
     print(Fore.GREEN + "\nOutputted settings file to `./output/weights.yaml`")
     meta_path = os.path.join("output", "meta.yaml")
     with open(meta_path, "w+") as file:

--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -101,9 +101,9 @@ def main():
                 raise ValueError(f"Could not find `{game}` top-level key in `{meta_path}`")
             meta.update(meta_settings)
 
-    with open("output/mystery.yaml", "w+") as file:
+    with open("output/weights.yaml", "w+") as file:
         yaml.dump(dict(mystery), file)
-    print(Fore.GREEN + "\nOutputted settings file to `./output/mystery.yaml`")
+    print(Fore.GREEN + "\nOutputted settings file to `./output/weights.yaml`")
     meta_path = os.path.join("output", "meta.yaml")
     with open(meta_path, "w+") as file:
         yaml.dump(meta, file)

--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -81,6 +81,10 @@ def main():
                     raise ValueError(f"Could not find `{game}` top-level key in `./games/{game}.yaml`")
 
                 mystery.update(game_settings)
+
+            with open(f"output/{game}.yaml", "w+") as game_file_output:
+                game_settings["name"] = data["name"]
+                yaml.dump(game_settings, game_file_output)
         except FileNotFoundError:
             print(Fore.RED + f"\nUnable to find game settings file `./games/{game}.yaml` in games directory.")
             exit(1)

--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -112,7 +112,7 @@ def main():
         for game in games:
             game_options = GameSettings(mystery["name"], mystery["description"], mystery["requires"], game, mystery[game])
             yaml.dump(dict(game_options), file)
-            if not last_key:
+            if game != last_key:
                 file.write("\n---\n\n")
     print(Fore.GREEN + "\nOutputted settings file to `./output/weights.yaml`")
     meta_path = os.path.join("output", "meta.yaml")

--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -38,6 +38,13 @@ class MysterySettings(dict):
         return games
 
 
+class GameSettings(MysterySettings):
+    def __init__(self, name: str, description: str, requires: dict, game: str, game_options: dict):
+        super().__init__(name, description, requires, game)
+
+        self[game] = game_options
+
+
 def main():
     # Create output directory, if it does not exist.
     if not os.path.exists("output/"):
@@ -81,10 +88,6 @@ def main():
                     raise ValueError(f"Could not find `{game}` top-level key in `./games/{game}.yaml`")
 
                 mystery.update(game_settings)
-
-            with open(f"output/{game}.yaml", "w+") as game_file_output:
-                game_settings["name"] = data["name"]
-                yaml.dump(game_settings, game_file_output)
         except FileNotFoundError:
             print(Fore.RED + f"\nUnable to find game settings file `./games/{game}.yaml` in games directory.")
             exit(1)
@@ -103,6 +106,11 @@ def main():
 
     with open("output/weights.yaml", "w+") as file:
         yaml.dump(dict(mystery), file)
+    with open("output/games.yaml", "w+") as file:
+        for game in mystery["game"]:
+            game_options = GameSettings(mystery["name"], mystery["description"], mystery["requires"], game, mystery[game])
+            yaml.dump(dict(game_options), file)
+            file.write("\n---\n\n")
     print(Fore.GREEN + "\nOutputted settings file to `./output/weights.yaml`")
     meta_path = os.path.join("output", "meta.yaml")
     with open(meta_path, "w+") as file:


### PR DESCRIPTION
this makes it so that GenerateMystery now outputs a valid file for each game in the output folder while it builds the weights file. also renames the output weights file to `weights.yaml` since that's what AP expects by default