### PR TITLE
Update Timespinner.yaml

### DIFF
--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -54,13 +54,7 @@ Timespinner:
   LootTierDistro: full_random
   ShowBestiary: true
   ShowDrops: true
-  TrapChance: 10
-  Traps:
-    - Meteor Sparrow Trap
-    - Poison Trap
-    - Chaos Trap
-    - Neurotoxin Trap
-    - Bee Trap
+  TrapChance: 0
     
   triggers:
     # swap Cantoran odds on an inverted start - it's an endgame boss location that can be as early as sphere 1 if inverted and quick seed are both true

--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -11,8 +11,8 @@ Timespinner:
   DownloadableItems: true
   LoreChecks: true
   Cantoran:
-    true: 50
-    false: 50
+    true: 75
+    false: 25
   GyreArchives:
     true: 67
     false: 33
@@ -61,3 +61,14 @@ Timespinner:
     - Chaos Trap
     - Neurotoxin Trap
     - Bee Trap
+    
+  triggers:
+    # swap Cantoran odds on an inverted start - it's an endgame boss location that can be as early as sphere 1 if inverted and quick seed are both true
+    - option_category: Timespinner
+      option_name: Inverted
+      option_result: true
+      options:
+        Timespinner:
+          Cantoran:
+            true: 25
+            false: 75

--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -14,8 +14,8 @@ Timespinner:
     true: 50
     false: 50
   GyreArchives:
-    true: 75
-    false: 25
+    true: 67
+    false: 33
   SpecificKeycards:
     true: 80
     false: 20
@@ -26,8 +26,8 @@ Timespinner:
     true: 80
     false: 20
   UnchainedKeys:
-    true: 80
-    false: 20
+    true: 67
+    false: 33
   EnterSandman:
     false: 75
     true: 25

--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -4,11 +4,15 @@ Timespinner:
   local_items: [Timespinner Gear 1, Timespinner Gear 2, Timespinner Gear 3]
   StartWithJewelryBox: true
   StartWithMeyef: true
-  QuickSeed: random
+  QuickSeed:
+    true: 50
+    false: 50
   PresentAccessWithWheelAndSpindle: true
   DownloadableItems: true
   LoreChecks: true
-  Cantoran: random
+  Cantoran:
+    true: 50
+    false: 50
   GyreArchives:
     true: 75
     false: 25

--- a/games/Timespinner.yaml
+++ b/games/Timespinner.yaml
@@ -1,36 +1,55 @@
 Timespinner:
   accessibility: items
+  DeathLink: false
   local_items: [Timespinner Gear 1, Timespinner Gear 2, Timespinner Gear 3]
   StartWithJewelryBox: true
-  DownloadableItems: true
-  EyeSpy: false
   StartWithMeyef: true
-  QuickSeed: false
-  SpecificKeycards: true
-  Inverted: random
-  GyreArchives: random
-  Cantoran: random
+  QuickSeed: random
+  PresentAccessWithWheelAndSpindle: true
+  DownloadableItems: true
   LoreChecks: true
-  BossRando: random
+  Cantoran: random
+  GyreArchives:
+    true: 75
+    false: 25
+  SpecificKeycards:
+    true: 80
+    false: 20
+  EyeSpy: 
+    true: 10
+    false: 90
+  Inverted:
+    true: 80
+    false: 20
+  UnchainedKeys:
+    true: 80
+    false: 20
+  EnterSandman:
+    false: 75
+    true: 25
+  DadPercent:
+    false: 80
+    true: 20
+  RisingTides:
+    false: 50
+    true: 50
+  DamageRando:
+    off: 50
+    balanced: 50
+  BossRando:
+    off: 25
+    scaled: 75
+  BossHealing: true
   EnemyRando: off
-  DamageRando: off
-  BossHealing: 'true'
-  ShopFill: default
+  ShopFill:
+    default: 33
+    randomized: 67
   ShopWarpShards: true
   LootPool: randomized
   DropRateCategory: randomized
   LootTierDistro: full_random
   ShowBestiary: true
   ShowDrops: true
-  EnterSandman:
-    false: 75
-    true: 25
-  DadPercent:
-    false: 75
-    true: 25
-  RisingTides:
-    false: 50
-    true: 50
   TrapChance: 10
   Traps:
     - Meteor Sparrow Trap
@@ -38,6 +57,3 @@ Timespinner:
     - Chaos Trap
     - Neurotoxin Trap
     - Bee Trap
-  PresentAccessWithWheelAndSpindle: true
-  UnchainedKeys: random
-  DeathLink: false


### PR DESCRIPTION
Tweaked a lot of weights for the purposes of all-filler asyncs, though honestly there's really nothing _so_ wild in Timespinner that it shouldn't still work pretty well for fillers in ones with customs as well even if they're maybe a bit spicier than before. The weights I did use are still a bit arbitrary and I'm entirely open to feedback. (If nothing else I think the chance of unscaled boss rando needed to be ripped out, it looks like it was an oversight from the last yaml change with the option changing from rando off/on and scaling off/on separate to just off/scaled/unscaled as one option)

Also rearranged a lot of options to group similar options together (e.g. ones that add starting inventory, ones that add locations, ones that are largely logic-impacting), the TS yaml has kind of tended to just keep slapping new options at the end which makes some stuff kind of weird to parse IMO.

Testing was just a quick gen to make sure I didn't outright break anything since I'm not doing anything especially weird with this one.