### PR TITLE
Update Muse Dash.yaml

### DIFF
--- a/games/Muse Dash.yaml
+++ b/games/Muse Dash.yaml
@@ -12,7 +12,7 @@ Muse Dash:
   chosen_traps:
     - Background Freeze Trap
     - Bad Apple Trap
-    - Chromatic Aberration Trap
+    #- Chromatic Aberration Trap
     - Error SFX Trap
     - Focus Line Trap
     - Gray Scale Trap


### PR DESCRIPTION
I know a lot of folks have a bit of trouble with Chromatic Aberration Trap and I just realized I can just. Not. with the changes to trap settings. (Did it as a comment rather than straight removal so it's easier to add back in later if minds change/identify it's not available when looking at the yaml, but am fine changing it to just ripping it out altogether if that's an issue.)