### PR TITLE
Tweak Filler Settings for LADX, SM64, and SMW

### DIFF
--- a/games/Links Awakening DX.yaml
+++ b/games/Links Awakening DX.yaml
@@ -2,35 +2,47 @@ Links Awakening DX:
   logic:
     normal: 1
   tradequest:
-    false: 3
-    true: 2
+    false: 1
+    true: 1
   goal:
     instruments: 5
-    seashells: 2
+    seashells: 3
   instrument_count:
-    random-high: 1
+    random-range-6-8: 1
   trendy_game:
     easy: 2
     normal: 5
     hard: 2
   shuffle_nightmare_keys:
     original_dungeon: 5
-    own_world: 3
+    own_dungeons: 5
+    own_world: 5
+    any_world: 3
+    different_world: 1
   shuffle_small_keys:
     original_dungeon: 5
-    own_world: 3
+    own_dungeons: 5
+    own_world: 5
+    any_world: 3
+    different_world: 1
   shuffle_maps:
     original_dungeon: 5
-    own_world: 3
-    any_world: 2
+    own_dungeons: 5
+    own_world: 5
+    any_world: 3
+    different_world: 1
   shuffle_compasses:
     original_dungeon: 5
-    own_world: 3
-    any_world: 2
+    own_dungeons: 5
+    own_world: 5
+    any_world: 3
+    different_world: 1
   shuffle_stone_beaks:
     original_dungeon: 5
-    own_world: 3
-    any_world: 2
+    own_dungeons: 5
+    own_world: 5
+    any_world: 3
+    different_world: 1
   warp_improvements: true
   additional_warp_points: true
   shuffle_instruments:
@@ -38,7 +50,21 @@ Links Awakening DX:
     own_dungeons: 10
     own_world: 10
     any_world: 5
-    vanilla: 50  
+    vanilla: 50
+  rooster:
+    false: 1
+    true: 1
+  experimental_dungeon_shuffle:
+    false: 3
+    true: 2
+  experimental_entrance_shuffle:
+    none: 3
+    simple: 1
+  boots_controls:
+    bracelet: 1
+  music:
+    vanilla: 10
+    shuffled: 1
   triggers:
     - option_category: Links Awakening DX
       option_name: goal

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -1,16 +1,16 @@
 Super Mario 64:
   area_rando:
     off: 5
-    courses_only: 3
-    courses_and_secrets_separate: 2
+    courses_only: 4
+    courses_and_secrets_separate: 3
     courses_and_secrets: 1
   progressive_keys: true
   enable_coin_stars:
     false: 5
     true: 2
   enable_move_rando:
-    true: 2
-    false: 5
+    true: 1
+    false: 1
   move_rando_actions:
     - Triple Jump
     - Long Jump
@@ -31,12 +31,16 @@ Super Mario 64:
   second_floor_star_door_cost: random-middle
   mips1_cost: random-middle
   mips2_cost: random-middle
-  stars_to_finish: random-range-middle-42-67
+  stars_to_finish: random-range-middle-42-100
   accessibility:
     items: 5
     locations: 2
   buddy_checks: random
-  exclamation_boxes: random
+  exclamation_boxes:
+    off: 1
+    1ups_only: 0
+  local_items:
+    1Up Mushroom
   completion_type:
     last_bowser_stage: 5
     all_bowser_stages: 2

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -31,7 +31,7 @@ Super Mario 64:
   second_floor_star_door_cost: random-middle
   mips1_cost: random-middle
   mips2_cost: random-middle
-  stars_to_finish: random-range-middle-42-100
+  stars_to_finish: random-range-middle-42-90
   accessibility:
     items: 5
     locations: 2

--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -38,12 +38,10 @@ Super Mario 64:
   buddy_checks: random
   exclamation_boxes:
     off: 1
-    1ups_only: 0
-  local_items:
-    1Up Mushroom
+    1ups_only: 1
   completion_type:
     last_bowser_stage: 5
-    all_bowser_stages: 2
+    all_bowser_stages: 3
   triggers:
     - option_category: Super Mario 64
       option_name: completion_type

--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -4,6 +4,9 @@ Super Mario World:
     yoshi_egg_hunt: 1
   local_items:
     Yoshi Egg
+    Thwimp Trap
+    Stun Trap
+    Literature Trap
   bosses_required: random-range-5-10
   max_yoshi_egg_cap: 50
   percentage_of_yoshi_eggs: 100

--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -1,15 +1,23 @@
 Super Mario World:
-  goal: bowser
+  goal:
+    bowser: 1
+    yoshi_egg_hunt: 1
+  local_items:
+    Yoshi Egg
   bosses_required: random-range-5-10
   max_yoshi_egg_cap: 50
   percentage_of_yoshi_eggs: 100
   dragon_coin_checks:
     false: 2
     true: 1
-  moon_checks: false
-  hidden_1up_checks: false
-  bonus_block_checks:
+  moon_checks:
     false: 2
+    true: 1
+  hidden_1up_checks:
+    false: 5
+    true: 1
+  bonus_block_checks:
+    false: 5
     true: 1
   blocksanity:
     false: 7
@@ -69,3 +77,9 @@ Super Mario World:
         Super Mario World:
           early_climb: true
           swap_donut_gh_exits: false
+    - option_category: Super Mario World
+      option_name: blocksanity
+      option_result: true
+      options:
+        Super Mario World:
+          max_yoshi_egg_cap: random-range-middle-50-255

--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -3,10 +3,10 @@ Super Mario World:
     bowser: 1
     yoshi_egg_hunt: 1
   local_items:
-    Yoshi Egg
-    Thwimp Trap
-    Stun Trap
-    Literature Trap
+    - Yoshi Egg
+    - Thwimp Trap
+    - Stun Trap
+    - Literature Trap
   bosses_required: random-range-5-10
   max_yoshi_egg_cap: 50
   percentage_of_yoshi_eggs: 100

--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -20,7 +20,7 @@ Super Mario World:
     false: 5
     true: 1
   blocksanity:
-    false: 7
+    false: 3
     true: 1
   bowser_castle_doors: vanilla
   bowser_castle_rooms:
@@ -41,12 +41,12 @@ Super Mario World:
   display_received_item_popups: progression
   junk_fill_percentage: 0
   trap_fill_percentage: random-low
+  stun_trap_weight: none
+  thwimp_trap_weight: none
+  literature_trap_weight: none
   ice_trap_weight: random
-  stun_trap_weight: random
-  literature_trap_weight: random
   timer_trap_weight: random
   reverse_trap_weight: random
-  thwimp_trap_weight: random
   autosave: true
   early_climb: false
   overworld_speed: fast
@@ -83,3 +83,6 @@ Super Mario World:
       options:
         Super Mario World:
           max_yoshi_egg_cap: random-range-middle-50-255
+          stun_trap_weight: random
+          thwimp_trap_weight: random
+          literature_trap_weight: random


### PR DESCRIPTION
### Link's Awakening DX

- Made tradequest equally likely
- Explicitly limit instrument range to 6-8
- Changed all dungeon item randomization to be the same across each type. Weighting favors local placement but does introduce `any_world` and `different_world` chances as well.
- Made rooster evenly weighted
- Added entrance shuffle weights. 3 : 2 for dungeons and 3 : 1 for simple entrances.
- Turned on the added functionality to use boots if you hold the bracelet button
- Added a rare chance (1 : 10) for the music to be shuffled

### Super Mario 64

- Slightly increased the chance that entrances are shuffled
- Made move rando an even chance
- Made endless stair star range extend from 42-90% of total stars
- Gave an even chance of 1Up Boxes being included or not
- Increased the odds of `All Bowsers` goal so that it is now 3 : 5 in favor of `Last Bowser`

### Super Mario World

- Added Yoshi Egg Hunt as an equal opportunity goal and made all Yoshi Eggs local
- Added moons as a potential check at 1 : 2 odds
- Added secret 1ups and bonus blocks at 1 : 5 odds
- Increased the odds of blocksanity from 1 : 7 to 1 : 3
- Stun, literature, and thwimp traps were removed
- If blocksanity is rolled, Yoshi Egg count can then be rolled between 50 - 255 favoring the middle of that range. Also, stun, thwimp, and literature traps are reintroduced as local items.