### PR TITLE
Noita: Random-high for extra orb option on peaceful ending

### DIFF
--- a/games/Noita.yaml
+++ b/games/Noita.yaml
@@ -54,7 +54,7 @@ Noita:
       options:
         Noita:
           extra_orbs:
-            random-low
+            random-high
           local_items:
             - Orb
           exclude_locations:


### PR DESCRIPTION
Looking at the current big async, there's a few slots that rolled peaceful ending with only 1 extra orb, and that looks annoying to deal with. So, I'd like to lower the chance of that happening.