### PR TITLE
Super Mario World: Set Display_Recieved_Item_Popups to default

### DIFF
--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -41,7 +41,6 @@ Super Mario World:
     full: 2
     singularity: 1
   swap_donut_gh_exits: true
-  display_received_item_popups: progression
   junk_fill_percentage: 0
   trap_fill_percentage: random-low
   stun_trap_weight: none


### PR DESCRIPTION
The current yaml sets item popups to Progression, which shows a notification for each Yoshi Egg collected regardless of goal. Since Yoshi Eggs are all local, and the game has several visual cues for collected eggs, this setting should be set to default.