### PR TITLE
Zork: Settings tweak and lower the weight some more

### DIFF
--- a/games/Zork Grand Inquisitor.yaml
+++ b/games/Zork Grand Inquisitor.yaml
@@ -4,10 +4,10 @@ Zork Grand Inquisitor:
   quick_port_foozle:
     true: 100
   start_with_hotspot_items:
-    false: 2
-    true: 1
-  deathsanity:
     false: 1
-    true: 2
+    true: 5
+  deathsanity:
+    false: 3
+    true: 1
   grant_missable_location_checks:
     true: 100

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -65,4 +65,4 @@ game:
   Yoshi's Island: 25
   Yu-Gi-Oh! 2006: 10
   Zillion: 7
-  Zork Grand Inquisitor: 7
+  Zork Grand Inquisitor: 5


### PR DESCRIPTION
Settings weights are more likely to be friendly to new players.

Game weight can go back up on the day someone complains that there weren't enough Zork slots. As the author, I don't think it's a good async game, and even people that like the randomizer know it BKs easily and don't want to use their world claims on it early on, so it should have very a low weight.