### PR TITLE
Refresh the SA2 yaml

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -2,6 +2,8 @@ Sonic Adventure 2 Battle:
   goal:
     biolizard: 3
     cannons_core_boss_rush: 1
+    boss_rush_chaos_emerald_hunt: 1
+    finalhazard_chaos_emerald_hunt: 1
   mission_shuffle: true
   boss_rush_shuffle:
     vanilla: 2
@@ -37,15 +39,32 @@ Sonic Adventure 2 Battle:
   level_gate_costs:
     medium: 1
     high: 2
-  chao_garden_difficulty:
+  chao_race_difficulty:
     none: 5
     beginner: 3
     intermediate: 1
     expert: 1
-  include_chao_karate:
-    false: 2
-    true: 1 
-  chao_race_checks: all
+  chao_karate_difficulty:
+    none: 5
+    beginner: 3
+    intermediate: 1
+    expert: 1
+  chao_stadium_checks: all
+  black_market_slots:
+    0: 3
+    random-low: 1
+    random-high: 1
+    64: 2
+  black_market_unlock_costs:
+    low: 3
+    medium: 2
+    high: 1
+  black_market_price_multiplier:
+    0: 1
+    1: 3
+    2: 1
+    3: 1
+    4: 1
   junk_fill_percentage: random-low
   trap_fill_percentage: random-low
   omochao_trap_weight: random
@@ -90,3 +109,4 @@ Sonic Adventure 2 Battle:
   cannons_core_mission_3: false
   cannons_core_mission_4: false
   cannons_core_mission_5: false
+  local_items: Chaos Emeralds

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -47,7 +47,7 @@ Sonic Adventure 2 Battle:
   chao_karate_difficulty:
     none: 5
     beginner: 3
-    intermediate: 1
+    standard: 1
     expert: 1
   chao_stadium_checks: all
   black_market_slots:

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -40,14 +40,9 @@ Sonic Adventure 2 Battle:
     medium: 1
     high: 2
   chao_race_difficulty:
-    none: 5
-    beginner: 3
+    none: 6
+    beginner: 4
     intermediate: 1
-    expert: 1
-  chao_karate_difficulty:
-    none: 5
-    beginner: 3
-    standard: 1
     expert: 1
   chao_stadium_checks: all
   black_market_slots:
@@ -117,4 +112,106 @@ Sonic Adventure 2 Battle:
       options:
         null:
           name: SA2B-{player}
-
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_race_difficulty
+      option_result: beginner
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty:
+                none: 2
+                beginner: 5
+                standard_override: 2
+                expert_override: 1
+                super_override: 1
+            chao_stats: '20'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_race_difficulty
+      option_result: none
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty:
+                none: 10
+                beginner_override: 3
+                standard_override: 1
+                expert_override: 1
+                super_override: 0
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_race_difficulty
+      option_result: intermediate
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty:
+                none: 2
+                beginner: 2
+                standard: 5
+                expert_override: 2
+                super_override: 1
+            chao_stats: '40'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_race_difficulty
+      option_result: expert
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty:
+                none: 2
+                beginner: 1
+                standard: 2
+                expert: 5
+                super_override: 3
+            chao_stats: '60'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_karate_difficulty
+      option_result: expert_override
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty: expert
+            chao_stats: '60'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_karate_difficulty
+      option_result: super_override
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty: super
+            chao_stats: '70'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_karate_difficulty
+      option_result: standard_override
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty: standard
+            chao_stats: '40'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: chao_karate_difficulty
+      option_result: beginner_override
+      options:
+        Sonic Adventure 2 Battle:
+            chao_karate_difficulty: beginner
+            chao_stats: '20'
+            chao_stats_frequency: 
+                '1': 1
+                '2': 1
+                '5': 1


### PR DESCRIPTION
Adds two additional goals in Chaos Emerald two of the Chaos Emerald Hunts, with the Emeralds set to local. Fixes the outdated Chao Garden logic to match what seems to be intended. Added Black Market checks.