### PR TITLE
Update Blasphemous.yaml

### DIFF
--- a/games/Blasphemous.yaml
+++ b/games/Blasphemous.yaml
@@ -56,6 +56,8 @@ Blasphemous:
   mask_location:
     anywhere: 3
     local: 1
+  local_items: [wounds]
+  exclude_locations: ["Skill 1, Tier 3", "Skill 5, Tier 3"] #locations apparently bugged in 0.5.0 and can accidentally self-lock local progression, can remove in 0.5.1
   
   triggers:
     - option_category: Blasphemous
@@ -92,9 +94,6 @@ Blasphemous:
       option_result: local
       options:
         Blasphemous:
-          local_items:
-          - Embossed Mask of Crescente
-          - Mirrored Mask of Dolphos
-          - Deformed Mask of Orestes
+          +local_items: [masks]
 
   


### PR DESCRIPTION
Half the game is gated by the three Holy Wounds, making these local by request of Blasphemous players.

Excluded two locations currently bugged to, as I understand it, be able to self-lock major progression - line can be removed with next AP update and is commented as such.

Updated local Masks trigger to add to rather than set local items list, condensed with item group.

Tested by rolling with some arbitrary other yamls, with local masks option forced both on and off to confirm trigger function after change