### PR TITLE
TUNIC: Add range for hex goal, use item group instead of individual item names

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -20,7 +20,7 @@ TUNIC:
   hexagon_quest:
     'true': 50
     'false': 50
-  hexagon_goal: random-middle
+  hexagon_goal: random-range-middle-15-50
   extra_hexagon_percentage: random-range-low-10-100
   lanternless: 'false'
   maskless: 'false'
@@ -28,10 +28,7 @@ TUNIC:
     anywhere: 50
     10_fairies: 50
   local_items:
-    - Red Questagon
-    - Blue Questagon
-    - Green Questagon
-    - Gold Questagon
+    - Questagons
 
   triggers:
     - option_category: TUNIC


### PR DESCRIPTION
Silent is planning to change the hex quest range, so I'm just getting ahead of that by making a random range for this to keep the hex amounts needed more sane.
Also using the item group instead of individually listing the items for local items