### PR TITLE
Update Secret of Evermore.yaml

### DIFF
--- a/games/Secret of Evermore.yaml
+++ b/games/Secret of Evermore.yaml
@@ -1,44 +1,51 @@
 Secret of Evermore:
   difficulty: # Changes relative spell cost and stuff
     easy: 0
-    normal: 33
-    hard: 33
-    mystery: 33
-  money_modifier:
-    150: 75
-    200: 25
-  exp_modifier:
-    150: 75
-    200: 25
-  fix_sequence: true  # Require Leviate for Volcano, Energy Core for Boss Rush
+    normal: 1
+    hard: 1
+    mystery: 1
+  energy_core: # How to obtain the Energy Core
+    vanilla: 1
+    shuffle: 3
+    fragments: 3
+  required_fragments: random-range-10-30 # Required fragment count for Energy Core = Fragments
+  available_fragments: random-range-high-20-40
+  money_modifier: random-range-150-250
+  exp_modifier: random-range-150-250
+  sequence_breaks: 
+    off: 4  # Require Leviate for Volcano, Energy Core for Boss Rush
+    on: 1   # Allow sequence breaks but do not consider them for logic
+  out_of_bounds:  # Allow out of bounds glitches
+    on: 1
+    off: 4
   fix_cheats: true  # Fix cheats left in by the devs (not desert skip)
   fix_infinite_ammo:  # Fix infinite ammo glitch
-    on: 80
-    off: 20
+    on: 1
+    off: 1
   fix_atlas_glitch: true  # Fix atlas underflowing stats
   fix_wings_glitch:  # Fix wings making you invincible in some areas
-    on: 80
-    off: 20
+    on: 1
+    off: 1
   shorter_dialogs: true  # Cuts some dialogs
   short_boss_rush:  # Start boss rush at Magmar, cut HP in half
-    on: 66
-    off: 33
+    on: 4
+    off: 1
   ingredienizer: # Shuffles or randomizes spell ingredients
-    on: 50
-    full: 50
+    on: 1
+    full: 1
   sniffamizer: 'shuffle' # Shuffles or randomizes drops in sniff locations
   sniff_ingredients:  # Randomizes the item pool for sniff ingredients
-    vanilla_ingredients: 50
-    random_ingredients: 50
+    vanilla_ingredients: 1
+    random_ingredients: 1
   callbeadamizer: # Shuffles call bead characters or spells
-    on: 50
-    full: 50
+    on: 1
+    full: 1
   musicmizer: false  # Randomize music for some rooms
   doggomizer: # On shuffles dog per act, Chaos randomizes dog per screen, Pupdunk gives you Everpupper everywhere
-    off: 30
-    on: 30
-    full: 30
-    pupdunk: 10
+    off: 3
+    on: 3
+    full: 3
+    pupdunk: 1
   turdo_mode: false  # Replace offensive spells by Turd Balls with varying strength and make weapons weak
   trap_count:  # Replace some filler items with traps
     0: 50
@@ -47,9 +54,10 @@ Secret of Evermore:
   trap_chance_poison: 20
   trap_chance_confound: 20
   trap_chance_hud: 20
-  trap_chance_ohko: 20
+  trap_chance_ohko: random-range-low-0-10 # Ohko is just bad
   local_items:
     - Traps
+    - Energy Core Fragment # Mcguffin
   triggers:
     # make it less likely to have a hard time with pupdunk
     - option_category: Secret of Evermore
@@ -58,12 +66,10 @@ Secret of Evermore:
       options:
         Secret of Evermore:
           difficulty:
-            normal: 50
-            pupdunk_hard: 25
-            pupdunk_mystery: 25
-          exp_modifier:
-            150: 50
-            200: 50
+            normal: 2
+            pupdunk_hard: 1
+            pupdunk_mystery: 1
+          exp_modifier: random-range-high-150-250
     - option_category: Secret of Evermore
       option_name: difficulty
       option_result: pupdunk_hard


### PR DESCRIPTION
This updates the Secret of Evermore filler in order to:
- add 20% of allowing sequence breaking and out of bounds glitch (but not considered in logic)
- allow the energy core to be vanilla or split into 10 to 30 fragments, with 25 to 40 in the pool (if the available amount of fragments rolls to be lower than the required amount, it is raised to equal the required amount)
- lower the amount of OHKO traps (OHKO is just bad, no matter which game)
- widen the range of experience and money modifiers

I've also clarified some of the weights, to be more legible (in my opinion).