### PR TITLE
Remove Infected Goal From Subnautica

### DIFF
--- a/games/Subnautica.yaml
+++ b/games/Subnautica.yaml
@@ -3,7 +3,6 @@ Subnautica:
   goal:
     launch: 3
     free: 2
-    infected: 1
   creature_scans:
     random-range-40-50: 1
   creature_scan_logic:


### PR DESCRIPTION
Remove infected goal from Subnautica as it can easily be cheesed with no items.