### PR TITLE
Update DOOM 1993.yaml

### DIFF
--- a/games/DOOM 1993.yaml
+++ b/games/DOOM 1993.yaml
@@ -1,8 +1,10 @@
 DOOM 1993:
+  goal: 
+    complete_boss_levels: 1
+    complete_all_levels: 4
   difficulty:
-    baby: 2
-    easy: 5
-    medium: 3
+    easy: 3
+    medium: 5
     hard: 1
   random_monsters:
     vanilla: 2
@@ -13,13 +15,21 @@ DOOM 1993:
     vanilla: 2
     shuffle: 7
     random_balanced: 3
-  allow_death_logic: false
+  random_music: random
+  flip_levels: random
+  allow_death_logic:
+    true: 1
+    false: 4
+  pro: false
   start_with_computer_area_maps: random
   death_link: false
+  reset_level_on_death: true
   episode1: true
-  episode2: random
-  episode3: random
-  episode4: random
+  episode2: 
+    true: 4
+    false: 1
+  episode3: false
+  episode4: false
   triggers:
     - option_category: null
       option_name: name
@@ -27,3 +37,25 @@ DOOM 1993:
       options:
         null:
           name: DOOM1993-{player}
+    - option_category: DOOM 1993
+      option_name: episode2
+      option_result: true
+      options:
+        DOOM 1993:
+          episode3: 
+            true: 4
+            false: 1
+    - option_category: DOOM 1993
+      option_name: episode3
+      option_result: true
+      options:
+        DOOM 1993:
+          episode4: 
+            true: 1
+            false: 3
+    - option_category: DOOM 1993
+      option_name: episode2
+      option_result: false
+      options:
+        DOOM 1993:
+          goal: complete_all_levels


### PR DESCRIPTION
-Death logic has a 1 in 5 chance to be true
-Difficulty tweaked towards medium, Baby removed
-Goal can be boss levels, unless the slot rolls as episode 1 only 
-Levels can be flipped
-Randomized music
-Episodes roll sequentially: Episode 4 can only roll true if 2 and 3 do first, episode 3 can only roll true if 2 does first 
-Episode 4 has a low chance of rolling since in my experience most players don't like it

This is my first time using triggers and my first time doing a github PR. Hope I didn't mess anything up