### PR TITLE
Make Floppies and Red ID Card Local

### DIFF
--- a/games/Zillion.yaml
+++ b/games/Zillion.yaml
@@ -25,9 +25,9 @@
     4: 7
     5: 1
   starting_cards: random-high
-  room_gen:
-    false: 60
-    true: 40
+  map_gen:
+    none: 60
+    rooms: 40
   local_items:
     Floppy Disk: 1
     Red ID Card: 1

--- a/games/Zillion.yaml
+++ b/games/Zillion.yaml
@@ -28,6 +28,9 @@
   room_gen:
     false: 60
     true: 40
+  local_items:
+    Floppy Disk: 1
+    Red ID Card: 1
   triggers:
     - option_category: null
       option_name: name


### PR DESCRIPTION
From an async perspective, this game is really gated by the Opa Opa Items and the Zillion Items.  Hunting for the Floppy Disks throughout an async multiworld isn't meaningful, because the only check gated by Floppies and the Red ID Card is the "Win" Check, whose sole purpose is to flag the world as cleared to AP.  To even get far enough to use Floppies and the Red ID Card requires enough Zillions and Opa Opas--so many in fact you can get every other check in the game.

Given that, making Floppies and the Red ID Card local means a player still has to acquire the right items to get all the necessary checks, they still have to hunt for a fair number of checks in their world due to needing the Floppy Disks, but they don't have to wait 2 weeks after otherwise clearing their world just to have the game formally cleared in AP.