### PR TITLE
Post Oct. Risk of Rain 2.yaml update

### DIFF
--- a/games/Risk of Rain 2.yaml
+++ b/games/Risk of Rain 2.yaml
@@ -40,3 +40,9 @@ Risk of Rain 2:
       options:
         null:
           name: RoR2-{player}
+    - option_category: Risk of Rain 2
+      option_name: victory
+      option_result: voidling
+      options:
+        Risk of Rain 2:
+          dlc_sotv: 'true'


### PR DESCRIPTION
Added a trigger to the Risk of Rain 2 yaml, turning on the Survivors of the Void DLC if the Voidling goal is rolled which allows the goal to actually be played instead of defaulting to the any goal instead.

There are 4 possible victory conditions, which means ~25% of slots will end up with DLC enabled.

It's also possible to enable the DLC for the "Any" victory condition since that adds another way to finish under those conditions, but given that DLC is currently set to always off I'm assuming we don't want to add too many DLC enabled slots.