### PR TITLE
Add more robust goal system to Minecraft

### DIFF
--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -1,7 +1,7 @@
 Minecraft:
   goal:
     advancements: 1
-    eggs: 1
+    eggs: 2
   combat_difficulty:
     easy: 10
     normal: 20
@@ -25,7 +25,7 @@ Minecraft:
         Minecraft:
             advancement_goal: random-range-60-80
             required_bosses:
-                none: 30
+                none: 20
                 ender_dragon: 20
                 wither: 20
                 both: 10

--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -34,7 +34,7 @@ Minecraft:
       option_result: eggs
       options:
         Minecraft:
-            advancement_goal: random-range-40-60
+            advancement_goal: random-range-40-70
             egg-shards-required: random-range-10-17
             egg-shards-available: 20
             local_items: Dragon Egg Shard

--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -1,5 +1,7 @@
 Minecraft:
-  advancement_goal: random-range-30-80
+  goal:
+    advancements: 1
+    eggs: 1
   combat_difficulty:
     easy: 10
     normal: 20
@@ -11,15 +13,36 @@ Minecraft:
   include_postgame_advancements: off
   shuffle_structures: on
   structure_compasses: on
-  required_bosses: # Bosses which must be defeated to finish the game.
-    none: 50
-    ender_dragon: 25
-    wither: 25
-    both: 10
   exclude_locations:
     - Two by Two
     - Monsters Hunted
+
   triggers:
+    - option_category: Minecraft
+      option_name: goal
+      option_result: advancements
+      options:
+        Minecraft:
+            advancement_goal: random-range-60-80
+            required_bosses:
+                none: 30
+                ender_dragon: 20
+                wither: 20
+                both: 10
+    - option_category: Minecraft
+      option_name: goal
+      option_result: eggs
+      options:
+        Minecraft:
+            advancement_goal: random-range-40-60
+            egg-shards-required: random-range-10-17
+            egg-shards-available: 20
+            local_items: Dragon Egg Shard
+            required_bosses: # Bosses which must be defeated to finish the game.
+                none: 50
+                ender_dragon: 20
+                wither: 20
+                both: 10
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
Adds a trigger for goal requirements. This allows two outcomes
- No eggs required, advancement count higher, more likely for bosses to be required
- Eggs required, advancement count a bit lower, same adds as last async for boss requirement.

This should heavily reduce the possibility of a day 1 clear, as it makes advancement-only much less likely (in the range of ~15%), and it will always require a reasonably hefty amount of advancements.

Based on discussion in the discord. Shoutouts to nidoskull (trying to prevent guilt from one upping his PR)