### PR TITLE
Add Grub Hunt to HK

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -68,11 +68,13 @@ Hollow Knight:
   StartLocation: king's_pass
   Goal:
     any: 1
-    hollowknight: 1
-    siblings: 1
-    radiance: 1
+    hollowknight: 2
+    siblings: 2
+    radiance: 2
     godhome: 0
     godhome_flower: 0
+    grub_hunt: 1
+  GrubHuntGoal: random-range-middle-25-35
   WhitePalace: 
     exclude: 5
     kingfragment: 0
@@ -129,6 +131,14 @@ Hollow Knight:
     medium: 1
   
   triggers:
+  - option_category: Hollow Knight
+    option_name: goal
+    option_result: grub_hunt
+    options:
+      Hollow Knight:
+        +local_items:
+          - Grubs
+  
   - option_category: Hollow Knight
     option_name: skips
     option_result: none

--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -67,13 +67,13 @@ Hollow Knight:
   RemoveSpellUpgrades: 'false'
   StartLocation: king's_pass
   Goal:
-    any: 1
-    hollowknight: 2
-    siblings: 2
-    radiance: 2
+    any: 2
+    hollowknight: 3
+    siblings: 3
+    radiance: 3
     godhome: 0
     godhome_flower: 0
-    grub_hunt: 1
+    grub_hunt: 2
   GrubHuntGoal: random-range-middle-25-35
   WhitePalace: 
     exclude: 5
@@ -134,6 +134,13 @@ Hollow Knight:
   - option_category: Hollow Knight
     option_name: goal
     option_result: grub_hunt
+    options:
+      Hollow Knight:
+        +local_items:
+          - Grubs
+  - option_category: Hollow Knight
+    option_name: goal
+    option_result: any
     options:
       Hollow Knight:
         +local_items:


### PR DESCRIPTION
Adds Grub Hunt to HK. If the goal is grub hunt, the required number of grubs is a random range from 25 to 35, and a trigger is set up to make grubs local.