### PR TITLE
Adding Kingdom Hearts

### DIFF
--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -1,16 +1,14 @@
 Kingdom Hearts:
   goal:
-    postcards: 25
-    final_ansem: 50
+    postcards: 15
+    final_ansem: 60
     puppies: 25
   end_of_the_world_unlock: item #Even though reports is the default math wise, this is cleaner to write than manually setting it for other goals each time
   final_rest_door: reports
   required_reports_eotw: 0 #Same idea as the End of the World unlock
   required_reports_door: 0
   reports_in_pool: 0
-  super_bosses:
-    'false': 85
-    'true': 15
+  super_bosses: false
   atlantica:
     'false': 50
     'true': 50
@@ -52,13 +50,13 @@ Kingdom Hearts:
   interact_in_battle: true
   advanced_logic: false
   extra_shared_abilities:
-    'false': 80
-    'true': 20
+    'false': 50
+    'true': 50
   exp_zero_in_pool: false
   donald_death_link: false
   goofy_death_link: false
   start_inventory_from_pool:
-    Scan: 1 #Nothing but love in my heart for players
+    Scan: 1 #Nothing but love in our hearts for players
   
   triggers:
     #Set this here to not trigger superboss settings on other goals
@@ -92,6 +90,7 @@ Kingdom Hearts:
       options:
         Kingdom Hearts:
           final_rest_door: postcards
+          super_bosses: true #Makes Postcards the only non-Superboss goal setting to have these checks enabled to set it apart from Puppies
           +start_hints: [Postcard]
           +local_items: [Postcard]
     #Locks Puppies to Triplets to be reasonable as a local goal. Same idea with the Final Door as Postcards

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -21,7 +21,7 @@ Kingdom Hearts:
   vanilla_emblem_pieces:
     'false': 50
     'true': 50
-  exp_multiplier: 4x
+  exp_multiplier: 3x
   level_checks: 100
   force_stats_on_levels: all
   strength_increase: 24

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -3,11 +3,11 @@ Kingdom Hearts:
     postcards: 20
     final_ansem: 60
     puppies: 20
-  end_of_the_world_unlock: item
+  end_of_the_world_unlock: item #Even though reports is the default math wise, this is cleaner to write than manually setting it for other goals each time
   final_rest_door:
     reports: 80
     superbosses: 20
-  required_reports_eotw: 0
+  required_reports_eotw: 0 #Same idea as the End of the World unlock
   required_reports_door: 0
   reports_in_pool: 0
   super_bosses:
@@ -63,12 +63,22 @@ Kingdom Hearts:
     Scan: 1 #Nothing but love in my heart for players
   
   triggers:
+    #Local Superboss unlock items and final world so this goal has some macguffins
     - option_name: final_rest_door
       option_category: Kingdom Hearts
       option_result: superbosses
       options:
         Kingdom Hearts:
           super_bosses: true
+          vanilla_emblem_pieces: false
+          +local_items:
+            - Cups
+            - Emblem Piece (Flame)
+            - Emblem Piece (Chest)
+            - Emblem Piece (Statue)
+            - Emblem Piece (Fountain)
+            - End of the World
+    #Hints the local Postcards to vary this goal up from Puppies. Door set to Postcards so reports can be out of the pool on non-report goals and enable the final boss after goal just for fun
     - option_name: goal
       option_category: Kingdom Hearts
       option_result: postcards
@@ -77,6 +87,7 @@ Kingdom Hearts:
           final_rest_door: postcards
           +start_hints: [Postcard]
           +local_items: [Postcard]
+    #Locks Puppies to Triplets to be reasonable as a local goal. Same idea with the Final Door as Postcards
     - option_name: goal
       option_category: Kingdom Hearts
       option_result: puppies
@@ -85,6 +96,7 @@ Kingdom Hearts:
           final_rest_door: puppies
           puppies: triplets
           +local_items: [Puppies]
+    #Adds reports back into the pool and makes them local.
     - option_name: final_rest_door
       option_category: Kingdom Hearts
       option_result: reports

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -1,16 +1,16 @@
 Kingdom Hearts:
   goal:
-    postcards: 20
-    final_ansem: 60
-    puppies: 20
+    postcards: 25
+    final_ansem: 50
+    puppies: 25
   end_of_the_world_unlock: item #Even though reports is the default math wise, this is cleaner to write than manually setting it for other goals each time
   final_rest_door: reports
   required_reports_eotw: 0 #Same idea as the End of the World unlock
   required_reports_door: 0
   reports_in_pool: 0
   super_bosses:
-    'false': 75
-    'true': 25
+    'false': 85
+    'true': 15
   atlantica:
     'false': 50
     'true': 50
@@ -18,8 +18,8 @@ Kingdom Hearts:
     'false': 80
     'true': 20
   cups:
-    'false': 70
-    'true': 30
+    'false': 50
+    'true': 50
   vanilla_emblem_pieces:
     'false': 50
     'true': 50
@@ -45,15 +45,15 @@ Kingdom Hearts:
   keyblade_min_mp: -2
   keyblade_max_mp: 3
   puppies:
-    full: 0
+    full: 25
     triplets: 50
-    individual: 0
+    individual: 25
   starting_worlds: 0
   interact_in_battle: true
   advanced_logic: false
   extra_shared_abilities:
-    'false': 90
-    'true': 10
+    'false': 80
+    'true': 20
   exp_zero_in_pool: false
   donald_death_link: false
   goofy_death_link: false
@@ -68,8 +68,8 @@ Kingdom Hearts:
       options:
         Kingdom Hearts:
           final_rest_door:
-            reports: 80
-            superbosses: 20
+            reports: 75
+            superbosses: 25
     #Local Superboss unlock items and final world so this goal has some macguffins
     - option_name: final_rest_door
       option_category: Kingdom Hearts

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -21,7 +21,7 @@ Kingdom Hearts:
   vanilla_emblem_pieces:
     'false': 50
     'true': 50
-  exp_multiplier: 4x #need to consult on this
+  exp_multiplier: 4x
   level_checks: 100
   force_stats_on_levels: all
   strength_increase: 24
@@ -29,8 +29,8 @@ Kingdom Hearts:
   hp_increase: 23
   ap_increase: 18
   mp_increase: 7
-  accessory_slot_increase: 1   #These two could probably be higher for QoL but I'm not certain yet
-  item_slot_increase: 3   #These two could probably be higher for QoL but I'm not certain yet
+  accessory_slot_increase: 1
+  item_slot_increase: 3
   keyblades_unlock_chests:
     'false': 75
     'true': 25

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -4,9 +4,7 @@ Kingdom Hearts:
     final_ansem: 60
     puppies: 20
   end_of_the_world_unlock: item #Even though reports is the default math wise, this is cleaner to write than manually setting it for other goals each time
-  final_rest_door:
-    reports: 80
-    superbosses: 20
+  final_rest_door: reports
   required_reports_eotw: 0 #Same idea as the End of the World unlock
   required_reports_door: 0
   reports_in_pool: 0
@@ -63,6 +61,15 @@ Kingdom Hearts:
     Scan: 1 #Nothing but love in my heart for players
   
   triggers:
+    #Set this here to not trigger superboss settings on other goals
+    - option_name: goal
+      option_category: Kingdom Hearts
+      option_result: final_ansem
+      options:
+        Kingdom Hearts:
+          final_rest_door:
+            reports: 80
+            superbosses: 20
     #Local Superboss unlock items and final world so this goal has some macguffins
     - option_name: final_rest_door
       option_category: Kingdom Hearts

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -107,6 +107,24 @@ Kingdom Hearts:
           required_reports_door: random-range-6-9
           reports_in_pool: random-range-9-13
           +local_items: [Reports]
+    #Exclude Hades Cup if superbosses are disabled
+    - option_name: super_bosses
+      option_category: Kingdom Hearts
+      option_result: 'false'
+      options:
+        Kingdom Hearts:
+          exclude_locations:
+            - "Olympus Coliseum Gates Purple Jar After Defeating Hades"
+            - "Olympus Coliseum Defeat Hades Ansem's Report 8"
+            - "Complete Hades Cup"
+            - "Complete Hades Cup Solo"
+            - "Complete Hades Cup Time Trial"
+            - "Hades Cup Defeat Cloud and Leon Event"
+            - "Hades Cup Defeat Yuffie Event"
+            - "Hades Cup Defeat Cerberus Event"
+            - "Hades Cup Defeat Behemoth Event"
+            - "Hades Cup Defeat Hades Event"
+            - "Olympus Coliseum Defeat Ice Titan Diamond Dust Event"
     - option_category: null
       option_name: name
       option_result: Player{player}

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -1,0 +1,103 @@
+Kingdom Hearts:
+  goal:
+    postcards: 20
+    final_ansem: 60
+    puppies: 20
+  end_of_the_world_unlock: item
+  final_rest_door:
+    reports: 80
+    superbosses: 20
+  required_reports_eotw: 0
+  required_reports_door: 0
+  reports_in_pool: 0
+  super_bosses:
+    'false': 75
+    'true': 25
+  atlantica:
+    'false': 50
+    'true': 50
+  hundred_acre_wood:
+    'false': 80
+    'true': 20
+  cups:
+    'false': 70
+    'true': 30
+  vanilla_emblem_pieces:
+    'false': 50
+    'true': 50
+  exp_multiplier: 4x #need to consult on this
+  level_checks: 100
+  force_stats_on_levels: all
+  strength_increase: 24
+  defense_increase: 24
+  hp_increase: 23
+  ap_increase: 18
+  mp_increase: 7
+  accessory_slot_increase: 1   #These two could probably be higher for QoL but I'm not certain yet
+  item_slot_increase: 3   #These two could probably be higher for QoL but I'm not certain yet
+  keyblades_unlock_chests:
+    'false': 75
+    'true': 25
+  randomize_keyblade_stats:
+    'false': 50
+    'true': 50
+  bad_starting_weapons: false
+  keyblade_min_str: 3
+  keyblade_max_str: 14
+  keyblade_min_mp: -2
+  keyblade_max_mp: 3
+  puppies:
+    full: 0
+    triplets: 50
+    individual: 0
+  starting_worlds: 0
+  interact_in_battle: true
+  advanced_logic: false
+  extra_shared_abilities:
+    'false': 90
+    'true': 10
+  exp_zero_in_pool: false
+  donald_death_link: false
+  goofy_death_link: false
+  start_inventory_from_pool:
+    Scan: 1 #Nothing but love in my heart for players
+  
+  triggers:
+    - option_name: final_rest_door
+      option_category: Kingdom Hearts
+      option_result: superbosses
+      options:
+        Kingdom Hearts:
+          super_bosses: true
+    - option_name: goal
+      option_category: Kingdom Hearts
+      option_result: postcards
+      options:
+        Kingdom Hearts:
+          final_rest_door: postcards
+          +start_hints: [Postcard]
+          +local_items: [Postcard]
+    - option_name: goal
+      option_category: Kingdom Hearts
+      option_result: puppies
+      options:
+        Kingdom Hearts:
+          final_rest_door: puppies
+          puppies: triplets
+          +local_items: [Puppies]
+    - option_name: final_rest_door
+      option_category: Kingdom Hearts
+      option_result: reports
+      options:
+        Kingdom Hearts:
+          end_of_the_world_unlock: reports
+          required_reports_eotw: random-range-3-6
+          required_reports_door: random-range-6-9
+          reports_in_pool: random-range-9-13
+          +local_items: [Reports]
+    - option_category: null
+      option_name: name
+      option_result: Player{player}
+      options:
+        null:
+          name: KH1-{player}

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -24,6 +24,7 @@ game:
   Heretic: 7
   Hollow Knight: 88
   Hylics 2: 7
+  Kingdom Hearts: 30
   Kingdom Hearts 2: 55
   Kirby's Dream Land 3: 20
   Landstalker - The Treasures of King Nole: 6


### PR DESCRIPTION
Adding Kingdom Hearts 1 with 4 goals of varying difficulty. The 4th goal is defined by the final boss unlock condition rather than the goal option as there isn't a setting for that with the same behavior.

- Final Ansem with Reports for the door is the standard beat the game goal with a variable amount of MacGuffins to unlock the boss. Intended to be the baseline difficulty for a slot, with KH1 itself having good difficulty options to make the game easier or harder to the player's preference.
- Puppies and Postcards are both MacGuffin hunts that goal on finding and turning in the last one, with Puppies having 33 items and Postcards only 10. Puppies is the intended easiest goal.
- Postcards is setup with triggers to offer a similar gameplay to KH2's Hitlist goal where the player can map out their required items from the start by having the Postcards start hinted. It's intended to be harder than Reports and at most as hard as the Superboss goal, as difficult locations are enabled but unlikely to all be required for goal.
- Final Ansem with Superboss for the door is intended to be the hardest goal as it will always require beating the game's most difficult content. KH1 has pretty solid fight logic though to make sure these are still reasonable to complete in logic. 
There is a known bug with one fight's logic currently that could potentially make it unbeatable in logic. I submitted a PR to GICU today to fix it but uncertain if it will make it to 0.5.1. If it's not, this goal can be changed to one of the alternate difficult boss goals and the locations excluded.

Other options were picked to provide a good mix of slots for different player preferences, while keeping things like leveling and stats on a single setting to work best in the Big Async.

Tested with a dozen or so 20 player generations and all options/triggers are working as intended.