### PR TITLE
Remove Blasphemous bug workaround

### DIFF
--- a/games/Blasphemous.yaml
+++ b/games/Blasphemous.yaml
@@ -57,7 +57,6 @@ Blasphemous:
     anywhere: 3
     local: 1
   local_items: [wounds]
-  exclude_locations: ["Skill 1, Tier 3", "Skill 5, Tier 3"] #locations apparently bugged in 0.5.0 and can accidentally self-lock local progression, can remove in 0.5.1
   
   triggers:
     - option_category: Blasphemous


### PR DESCRIPTION
As it says on the tin, had had a couple locations excuded per discussion in thread before the last async because they could be blockers if they had progression, even at the time I was told the fix was already merged and waiting for 0.5.1, which is now out.