### PR TITLE
Update A Short Hike.yaml

### DIFF
--- a/games/A Short Hike.yaml
+++ b/games/A Short Hike.yaml
@@ -10,7 +10,6 @@ A Short Hike:
   golden_feather_progression:
     easy: 2
     normal: 3
-  cost_multiplier: random-range-25-200
   filler_coin_amount: random
   triggers:
     - option_category: null


### PR DESCRIPTION
The shop cost multiplier does nothing. Its entire existence is a lie. I'm not knowledgeable enough to make a PR to make the option stop existing but I can at least make the big async game options page stop lying to people by just making it default anyway.

Multiple citations of the option doing nothing, the most recent within the past month:
https://discord.com/channels/731205301247803413/1224389725922787389/1233926411060904076
https://discord.com/channels/731205301247803413/1224389725922787389/1239197843567280148
https://discord.com/channels/731205301247803413/1224389725922787389/1309934638722056192

Release log for ASH rando mod including no updates mentioning its implementation at any time since any of those messages (1.1.0 was the current version at its official inclusion in AP):
https://github.com/BrandenEK/AShortHike.Randomizer/releases

Also my slot in the current async should have an 82% cost multiplier and it both quotes 100 for checks that cost 100 in vanilla and I have observed that yes it does still take 100.