### PR TITLE
Kingdom Hearts Cleanup and Updates

### DIFF
--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -10,33 +10,35 @@ Kingdom Hearts:
   reports_in_pool: 0
   super_bosses: false
   atlantica:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   hundred_acre_wood:
-    'false': 80
-    'true': 20
+    false: 80
+    true: 20
   cups:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   vanilla_emblem_pieces:
-    'false': 50
-    'true': 50
-  exp_multiplier: 3x
+    false: 50
+    true: 50
+  exp_multiplier: 4x
   level_checks: 100
-  force_stats_on_levels: all
+  force_stats_on_levels: 
+    all: 50
+    multiworld-to-level-50: 50
   strength_increase: 24
   defense_increase: 24
   hp_increase: 23
   ap_increase: 18
   mp_increase: 7
-  accessory_slot_increase: 1
+  accessory_slot_increase: 6
   item_slot_increase: 3
   keyblades_unlock_chests:
-    'false': 75
-    'true': 25
+    false: 75
+    true: 25
   randomize_keyblade_stats:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   bad_starting_weapons: false
   keyblade_min_str: 3
   keyblade_max_str: 14
@@ -50,15 +52,14 @@ Kingdom Hearts:
   interact_in_battle: true
   advanced_logic: false
   extra_shared_abilities:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   exp_zero_in_pool: false
   donald_death_link: false
   goofy_death_link: false
   start_inventory_from_pool:
     Scan: 1 #Nothing but love in our hearts for players
-  exclude_locations:
-    - "Monstro Chamber 6 White Trinity Chest"
+    Dodge Roll: 1
   
   triggers:
     #Set this here to not trigger superboss settings on other goals
@@ -115,13 +116,20 @@ Kingdom Hearts:
           required_reports_door: random-range-6-9
           reports_in_pool: random-range-9-13
           +local_items: [Reports]
+    #Makes the other stat increases local if level checks are on
+    - option_name: force_stats_on_levels
+      option_category: Kingdom Hearts
+      option_result: multiworld-to-level-50
+      options:
+        Kingdom Hearts:
+          +local_items: [Level Up, Limited Level Up]
     #Exclude Hades Cup if superbosses are disabled
     - option_name: super_bosses
       option_category: Kingdom Hearts
-      option_result: 'false'
+      option_result: false
       options:
         Kingdom Hearts:
-          exclude_locations:
+          +exclude_locations:
             - "Olympus Coliseum Gates Purple Jar After Defeating Hades"
             - "Olympus Coliseum Defeat Hades Ansem's Report 8"
             - "Complete Hades Cup"
@@ -133,6 +141,14 @@ Kingdom Hearts:
             - "Hades Cup Defeat Behemoth Event"
             - "Hades Cup Defeat Hades Event"
             - "Olympus Coliseum Defeat Ice Titan Diamond Dust Event"
+    #Exclude unreachable location on 0.5.1 when using Keyblades Unlock Chests
+    - option_name: keyblades_unlock_chests
+      option_category: Kingdom Hearts
+      option_result: true
+      options:
+        Kingdom Hearts:
+          +exclude_locations:
+            - "Monstro Chamber 6 White Trinity Chest"
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
- Raised EXP rate and Accessory Slots in pool to make leveling easier
- Added multiworld checks on levels and a trigger to make stat increases rewards local. Otherwise some slots could be exceptionally difficult waiting on stat increases from the async.
- Added Dodge Roll to the starting inventory as a QoL change
- Unreachable location is now only excluded on the relevant settings
- Fixed error that caused the Hades Cup exclusions to not work
- General cleanup of how true/false are written so I don't mess something up again