### PR TITLE
Added Voidling goal to the Victory Condition randomization

### DIFF
--- a/games/Risk of Rain 2.yaml
+++ b/games/Risk of Rain 2.yaml
@@ -4,8 +4,9 @@ Risk of Rain 2:
     explore: 100
   victory:
     any: 25
-    mithrix: 26
+    mithrix: 25
     limbo: 25
+    voidling: 25
   total_locations: random-range-60-200
   chests_per_stage: random-range-high-5-15
   shrines_per_stage: random-low


### PR DESCRIPTION
The trigger will actually work now, and I tested it by generating a game that rolled Voidling and ensuring it actually kept the Voidling goal with the DLC on.