### PR TITLE
Randomize shop slots for Hollow Knight

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -95,16 +95,16 @@ Hollow Knight:
   RandomCharmCosts: -2
   MinimumEggPrice: 1
   MaximumEggPrice: 10
-  EggShopSlots: 5
-  SlyShopSlots: 8
-  SlyKeyShopSlots: 6
-  IseldaShopSlots: 2
-  SalubraShopSlots: 5
-  SalubraCharmShopSlots: 5
-  LegEaterShopSlots: 3
-  GrubfatherRewardSlots: 7
-  SeerRewardSlots: 8
-  ExtraShopSlots: 0
+  EggShopSlots: 1
+  SlyShopSlots: 1
+  SlyKeyShopSlots: 1
+  IseldaShopSlots: 1
+  SalubraShopSlots: 1
+  SalubraCharmShopSlots: 1
+  LegEaterShopSlots: 1
+  GrubfatherRewardSlots: 1
+  SeerRewardSlots: 1
+  ExtraShopSlots: 40
   SplitCrystalHeart: 'random'
   SplitMothwingCloak: 'random'
   SplitMantisClaw: 'random'

--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -104,7 +104,7 @@ Hollow Knight:
   LegEaterShopSlots: 1
   GrubfatherRewardSlots: 1
   SeerRewardSlots: 1
-  ExtraShopSlots: 40
+  ExtraShopSlots: random-range-middle-30-50
   SplitCrystalHeart: 'random'
   SplitMothwingCloak: 'random'
   SplitMantisClaw: 'random'


### PR DESCRIPTION
This PR takes the existing shop allocations, leaves 1 guaranteed for each shop, and allocates the rest to `ExtraShopSlots`, which get distributed randomly to all shops.