### PR TITLE
Enable costsanity for Hollow Knight

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -109,14 +109,15 @@ Hollow Knight:
   SplitMothwingCloak: 'random'
   SplitMantisClaw: 'random'
   CostSanity:
-    off: 3
+    off: 4
+    shops_only: 1
     on: 1
   CostSanityHybridChance: 10
   CostSanityEggWeight: 1
-  CostSanityGrubWeight: 1
-  CostSanityEssenceWeight: 1
-  CostSanityCharmWeight: 1
-  CostSanityGeoWeight: 8
+  CostSanityGrubWeight: 2
+  CostSanityEssenceWeight: 2
+  CostSanityCharmWeight: 2
+  CostSanityGeoWeight: 16
   local_items:
     - Monomon
     - Lurien

--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -108,7 +108,9 @@ Hollow Knight:
   SplitCrystalHeart: 'random'
   SplitMothwingCloak: 'random'
   SplitMantisClaw: 'random'
-  CostSanity: off
+  CostSanity:
+    off: 3
+    on: 1
   CostSanityHybridChance: 10
   CostSanityEggWeight: 1
   CostSanityGrubWeight: 1


### PR DESCRIPTION
Vanilla cost weights have been left as-is. They can be tweaked later with player feedback.
Considered adding a 3/1/1 split of off/shops_only/on,, but figured I'd leave it simple for now.