### PR TITLE
MLSS: Remove "boss_normal" to prevent softlocks

### DIFF
--- a/games/Mario & Luigi Superstar Saga.yaml
+++ b/games/Mario & Luigi Superstar Saga.yaml
@@ -50,7 +50,6 @@ Mario & Luigi Superstar Saga:
   randomize_bosses:
     disabled: 30
     boss_only: 40
-    boss_normal: 30
 
   scale_stats: 
     false: 100
@@ -154,13 +153,6 @@ Mario & Luigi Superstar Saga:
           scale_stats:
             true: 100
 
-    - option_category: Mario & Luigi Superstar Saga
-      option_name: randomize_bosses
-      option_result: normal
-      options:
-        Mario & Luigi Superstar Saga:
-          scale_stats:
-            true: 100
 
     - option_category: null
       option_name: name

--- a/games/Mario & Luigi Superstar Saga.yaml
+++ b/games/Mario & Luigi Superstar Saga.yaml
@@ -153,7 +153,6 @@ Mario & Luigi Superstar Saga:
           scale_stats:
             true: 100
 
-
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
Apparently, first-striking an encounter with a Boss enemy in it on 0.5.1 AP breaks things. Once that's fixed, it can be added back in.