### PR TITLE
PokéEmerald: No Blind Trainersanity

### DIFF
--- a/games/Pokemon Emerald.yaml
+++ b/games/Pokemon Emerald.yaml
@@ -252,6 +252,15 @@ Pokemon Emerald:
           wild_encounter_blacklist: []
           normalize_encounter_rates: true
           guaranteed_catch: true
+          
+    # No blind trainers if trainersanity is enabled
+    - option_category: Pokemon Emerald
+      option_name: trainersanity
+      option_result: true
+      options:
+        Pokemon Emerald:
+          blind_trainers: false
+
 
     # Blacklist trainer legendaries
     - option_category: Pokemon Emerald


### PR DESCRIPTION
Removes Blind Trainers if Trainersanity is on.