### PR TITLE
Update Pokemon Red and Blue.yaml

### DIFF
--- a/games/Pokemon Red and Blue.yaml
+++ b/games/Pokemon Red and Blue.yaml
@@ -177,7 +177,6 @@ Pokemon Red and Blue:
         Pokemon Red and Blue:
           trainersanity: full
           dexsanity: disabled
-          blind_trainers: 0
           exp_modifier: 
             16: 50
             32: 25
@@ -209,11 +208,12 @@ Pokemon Red and Blue:
       option_result: both
       options:
         Pokemon Red and Blue:
-          trainersanity: full
+          trainersanity:
+            random-range-60-200: 30
+            full: 10
           dexsanity: 
             random-range-30-100: 30
             full: 10
-          blind_trainers: 0
           minimum_steps_between_encounters: 3
           exp_modifier: 
             16: 50


### PR DESCRIPTION
As of 0.5.1 trainersanity is no longer all or nothing; tweaked the trigger for "both dex- and trainersanity" to make the trainersanity most likely partial. Weights and range bounds modeled off the dexsanity values (full trainersanity is 317 so did similar proportions out of 317 as dexsanity does out of 151).

Additionally removed blind trainers values from the triggers as trainers with checks now ignore the setting entirely, making the option there superfluous.