### PR TITLE
Update DS3

### DIFF
--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -45,9 +45,7 @@
   smooth_soul_items: 'true'
   smooth_upgrade_items: 'true'
   smooth_upgraded_weapons: 'true'
-  randomize_enemies:
-    'false': 25
-    'true': 75
+  randomize_enemies: 'false'
   simple_early_bosses: 'true'
   scale_enemies: 'true'
   randomize_mimics_with_enemies: 'false'

--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -59,7 +59,7 @@
     # Can be unobtainable in certain local locations
     ['Path of the Dragon']
   exclude_locations:
-    ['Small Souls', 'Miscellaneous', 'Hidden', 'Small Crystal Lizards', 'Upgrade']
+    ['Small Souls', 'Miscellaneous', 'Hidden', 'Small Crystal Lizards', 'Upgrade', "AL: Aldrich's Ruby - dark cathedral, miniboss"]
   excluded_location_behavior: forbid_useful
   missable_location_behavior: forbid_useful
   triggers:

--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -10,8 +10,8 @@
     after_basin: 50
   death_link: 'false'
   enable_dlc:
-    'false': 75
-    'true': 25
+    'false': 7
+    'true': 1
   enable_ngp: 'false'
   random_starting_loadout:
     'false': 25

--- a/games/Dark Souls III.yaml
+++ b/games/Dark Souls III.yaml
@@ -1,13 +1,37 @@
-Dark Souls III:
-  local_items:
-    ["Small Lothric Banner","Cinders of a Lord - Abyss Watcher","Cinders of a Lord - Yhorm the Giant","Cinders of a Lord - Aldrich","Cinders of a Lord - Lothric Prince"]
-  auto_equip:
-    false: 50
-  lock_equip:
-    false: 50
+﻿Dark Souls III:
+  early_banner: early_local
+  late_basin_of_vows:
+    'off': 25
+    after_small_lothric_banner: 50
+    after_small_doll: 50
+  late_dlc:
+    'off': 25
+    after_small_doll: 50
+    after_basin: 50
+  death_link: 'false'
+  enable_dlc:
+    'false': 75
+    'true': 25
+  enable_ngp: 'false'
+  random_starting_loadout:
+    'false': 25
+    'true': 75
+  require_one_handed_starting_weapons: 'true'
+  auto_equip: 'false'
+  lock_equip: 'false'
+  no_equip_load:
+    'false': 2
+    'true': 3
   no_weapon_requirements:
-    false: 2
-    true: 3
+    'false': 2
+    'true': 3
+  no_spell_requirements:
+    'false': 2
+    'true': 3
+  randomize_infusion:
+    'false': 50
+    'true': 50
+  randomize_infusion_percentage: random
   randomize_weapon_level:
     all: 5
     basic: 1
@@ -18,56 +42,28 @@ Dark Souls III:
   max_levels_in_5: 5
   min_levels_in_10: 1
   max_levels_in_10: 10
-  late_basin_of_vows:
-    false: 1
-    true: 5
-  no_spell_requirements:
-    false: 2
-    true: 3
-  no_equip_load:
-    false: 2
-    true: 3
-  death_link:
-    false: 50
-  enable_progressive_locations:
-    true: 1
-    false: 3
-  enable_dlc:
-    true: 1
-    false: 24
-  enable_weapon_locations:
-    true: 50
-    false: 50
-  enable_shield_locations:
-    true: 50
-    false: 50
-  enable_armor_locations:
-    true: 50
-    false: 50
-  enable_ring_locations:
-    true: 50
-    false: 50
-  enable_spell_locations:
-    true: 50
-    false: 50
-  enable_key_locations:
-    true: 50
-  enable_boss_locations:
-    true: 50
-  enable_npc_locations:
-    true: 50
-    false: 50
-  enable_misc_locations:
-    true: 50
-    false: 50
-  enable_health_upgrade_locations:
-    true: 50
-    false: 50
-  pool_type: shuffle
-  randomize_infusion:
-    true: 50
-    false: 50
-  randomize_infusion_percentage: random
+  smooth_soul_items: 'true'
+  smooth_upgrade_items: 'true'
+  smooth_upgraded_weapons: 'true'
+  randomize_enemies:
+    'false': 25
+    'true': 75
+  simple_early_bosses: 'true'
+  scale_enemies: 'true'
+  randomize_mimics_with_enemies: 'false'
+  randomize_small_crystal_lizards_with_enemies: 'false'
+  reduce_harmless_enemies: 'false'
+  all_chests_are_mimics: 'false'
+  impatient_mimics: 'false'
+  local_items:
+    ["Cinders of a Lord - Abyss Watcher", "Cinders of a Lord - Yhorm the Giant", "Cinders of a Lord - Aldrich", "Cinders of a Lord - Lothric Prince"]
+  non_local_items:
+    # Can be unobtainable in certain local locations
+    ['Path of the Dragon']
+  exclude_locations:
+    ['Small Souls', 'Miscellaneous', 'Hidden', 'Small Crystal Lizards', 'Upgrade']
+  excluded_location_behavior: forbid_useful
+  missable_location_behavior: forbid_useful
   triggers:
     - option_category: null
       option_name: name
@@ -75,4 +71,3 @@ Dark Souls III:
       options:
         null:
           name: DS3-{player}
-

--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -10,33 +10,35 @@ Kingdom Hearts:
   reports_in_pool: 0
   super_bosses: false
   atlantica:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   hundred_acre_wood:
-    'false': 80
-    'true': 20
+    false: 80
+    true: 20
   cups:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   vanilla_emblem_pieces:
-    'false': 50
-    'true': 50
-  exp_multiplier: 3x
+    false: 50
+    true: 50
+  exp_multiplier: 4x
   level_checks: 100
-  force_stats_on_levels: all
+  force_stats_on_levels: 
+    all: 50
+    multiworld-to-level-50: 50
   strength_increase: 24
   defense_increase: 24
   hp_increase: 23
   ap_increase: 18
   mp_increase: 7
-  accessory_slot_increase: 1
+  accessory_slot_increase: 6
   item_slot_increase: 3
   keyblades_unlock_chests:
-    'false': 75
-    'true': 25
+    false: 75
+    true: 25
   randomize_keyblade_stats:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   bad_starting_weapons: false
   keyblade_min_str: 3
   keyblade_max_str: 14
@@ -50,15 +52,14 @@ Kingdom Hearts:
   interact_in_battle: true
   advanced_logic: false
   extra_shared_abilities:
-    'false': 50
-    'true': 50
+    false: 50
+    true: 50
   exp_zero_in_pool: false
   donald_death_link: false
   goofy_death_link: false
   start_inventory_from_pool:
     Scan: 1 #Nothing but love in our hearts for players
-  exclude_locations:
-    - "Monstro Chamber 6 White Trinity Chest"
+    Dodge Roll: 1
   
   triggers:
     #Set this here to not trigger superboss settings on other goals
@@ -115,13 +116,20 @@ Kingdom Hearts:
           required_reports_door: random-range-6-9
           reports_in_pool: random-range-9-13
           +local_items: [Reports]
+    #Makes the other stat increases local if level checks are on
+    - option_name: force_stats_on_levels
+      option_category: Kingdom Hearts
+      option_result: multiworld-to-level-50
+      options:
+        Kingdom Hearts:
+          +local_items: [Level Up, Limited Level Up]
     #Exclude Hades Cup if superbosses are disabled
     - option_name: super_bosses
       option_category: Kingdom Hearts
-      option_result: 'false'
+      option_result: false
       options:
         Kingdom Hearts:
-          exclude_locations:
+          +exclude_locations:
             - "Olympus Coliseum Gates Purple Jar After Defeating Hades"
             - "Olympus Coliseum Defeat Hades Ansem's Report 8"
             - "Complete Hades Cup"
@@ -133,6 +141,14 @@ Kingdom Hearts:
             - "Hades Cup Defeat Behemoth Event"
             - "Hades Cup Defeat Hades Event"
             - "Olympus Coliseum Defeat Ice Titan Diamond Dust Event"
+    #Exclude unreachable location on 0.5.1 when using Keyblades Unlock Chests
+    - option_name: keyblades_unlock_chests
+      option_category: Kingdom Hearts
+      option_result: true
+      options:
+        Kingdom Hearts:
+          +exclude_locations:
+            - "Monstro Chamber 6 White Trinity Chest"
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
Updating DS3 with new options and removing old ones. 
- I increased the chance of the DLC being enabled to not be ~4% where it might not ever roll, but still be on the low end so there's plenty of slots for players that don't own it.
- Path of the Dragon is forced non-local as it can be unobtainable in certain local locations currently.
- Randomize Starting Loadout  I gave a 1/4 chance to be off since I assume some players might want a more non-randomized experience for that (I know I like picking certain starting classes)
- Randomize Enemies I turned off as I see way too many frequent reports of crashing because of it and it doesn't seem stable enough to enable in the async.