### PR TITLE
Disable Legend goal for SDV

### DIFF
--- a/games/Stardew Valley.yaml
+++ b/games/Stardew Valley.yaml
@@ -10,7 +10,6 @@ Stardew Valley:
     full_shipment: 3
     gourmet_chef: 3
     craft_master: 2
-    legend: 3
     mystery_of_the_stardrops: 8
   farm_type: random
   starting_money: random-range-1000-25000

--- a/games/Stardew Valley.yaml
+++ b/games/Stardew Valley.yaml
@@ -4,10 +4,10 @@ Stardew Valley:
     community_center: 50
     grandpa_evaluation: 20
     bottom_of_the_mines: 3
-    master_angler: 3
+    master_angler: 4
     complete_collection: 2
-    protector_of_the_valley: 3
-    full_shipment: 3
+    protector_of_the_valley: 4
+    full_shipment: 4
     gourmet_chef: 3
     craft_master: 2
     mystery_of_the_stardrops: 8


### PR DESCRIPTION
The legend goal is pretty much always available in Sphere1, and is even easier to get in 1.6.
Rather than trying to make trigger to force people to do the same menial task for longer, I'll just disable the goal entirely.