### PR TITLE
Update Factorio.yaml

### DIFF
--- a/games/Factorio.yaml
+++ b/games/Factorio.yaml
@@ -19,6 +19,7 @@ Factorio:
     spawn: 2
   satellite: random
   free_samples: stack
+  free_samples_quality: random
   tech_tree_information: none
   starting_items:
     # Mapping of Factorio internal item-name to amount granted on start.


### PR DESCRIPTION
uses free samples quality, which needs the payed mod quality to work, but, if the mod is not loaded the option simply fizzles doing nothing.