### PR TITLE
ChecksFinder is too long a name

### DIFF
--- a/games/ChecksFinder.yaml
+++ b/games/ChecksFinder.yaml
@@ -5,4 +5,4 @@ ChecksFinder:
       option_result: Player{player}
       options:
         null:
-          name: ChecksFinder-{player}  
+          name: CF-{player}


### PR DESCRIPTION
We have a maximum of 11 characters in the world name to allow for the dash and four numbers for the slot