### PR TITLE
TUNIC: 0.6.0 options

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,7 +1,7 @@
 TUNIC:
   # column order for the spreadsheet:
   # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Entrance Rando | Fewer Shops | 
-  # Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
+  # Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
   # if Hexagon Quest is disabled, put a - for Gold Hexagons Required and Percentage of Extra Hexagons since they are not relevant
   sword_progression: 'true'
   start_with_sword:
@@ -27,6 +27,13 @@ TUNIC:
   laurels_location:
     anywhere: 50
     10_fairies: 50
+  combat_logic:
+    on: 40
+    bosses_only: 20
+    off: 40
+  grass_randomizer:
+    'true': 0
+    'false': 100
   local_items:
     - Questagons
 

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,7 +1,7 @@
 TUNIC:
   # column order for the spreadsheet:
   # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Entrance Rando | Fewer Shops | 
-  # Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
+  # Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
   # if Hexagon Quest is disabled, put a - for Gold Hexagons Required and Percentage of Extra Hexagons since they are not relevant
   sword_progression: 'true'
   start_with_sword:
@@ -27,10 +27,10 @@ TUNIC:
   laurels_location:
     anywhere: 50
     10_fairies: 50
-  # combat_logic:
-  #   on: 40
-  #   bosses_only: 20
-  #   off: 40
+  combat_logic:
+    on: 40
+    bosses_only: 20
+    off: 40
   grass_randomizer:
     'true': 0
     'false': 100

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,7 +1,7 @@
 TUNIC:
   # column order for the spreadsheet:
   # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Entrance Rando | Fewer Shops | 
-  # Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
+  # Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
   # if Hexagon Quest is disabled, put a - for Gold Hexagons Required and Percentage of Extra Hexagons since they are not relevant
   sword_progression: 'true'
   start_with_sword:
@@ -27,10 +27,10 @@ TUNIC:
   laurels_location:
     anywhere: 50
     10_fairies: 50
-  combat_logic:
-    on: 40
-    bosses_only: 20
-    off: 40
+  # combat_logic:
+  #   on: 40
+  #   bosses_only: 20
+  #   off: 40
   grass_randomizer:
     'true': 0
     'false': 100

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,8 +1,8 @@
 TUNIC:
   # column order for the spreadsheet:
-  # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Entrance Rando | Fewer Shops | 
-  # Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
-  # if Hexagon Quest is disabled, put a - for Gold Hexagons Required and Percentage of Extra Hexagons since they are not relevant
+  # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Hexagon Quest Ability Type 
+  # Entrance Rando | Fewer Shops | Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
+  # if Hexagon Quest is disabled, put a - for Gold Hexagons Required, Percentage of Extra Hexagons, and Hexagon Quest Ability Type since they are not relevant
   sword_progression: 'true'
   start_with_sword:
     'true': 25
@@ -22,6 +22,7 @@ TUNIC:
     'false': 50
   hexagon_goal: random-range-middle-15-50
   extra_hexagon_percentage: random-range-low-10-100
+  hexagon_quest_ability_type: random
   lanternless: 'false'
   maskless: 'false'
   laurels_location:
@@ -31,6 +32,9 @@ TUNIC:
     on: 40
     bosses_only: 20
     off: 40
+  breakable_shuffle:
+    'true': 40
+    'false': 60
   grass_randomizer:
     'true': 0
     'false': 100

--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -1,6 +1,6 @@
 TUNIC:
   # column order for the spreadsheet:
-  # Start with Sword | Keys Behind Bosses | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Hexagon Quest Ability Type 
+  # Start with Sword | Hexagon Quest | Gold Hexagons Required | Percentage of Extra Hexagons | Hexagon Quest Ability Type | Breakable Shuffle | Keys Behind Bosses
   # Entrance Rando | Fewer Shops | Addtl Combat Logic | Laurels Location | Laurels Zips | Ice Grappling | Ladder Storage
   # if Hexagon Quest is disabled, put a - for Gold Hexagons Required, Percentage of Extra Hexagons, and Hexagon Quest Ability Type since they are not relevant
   sword_progression: 'true'


### PR DESCRIPTION
Additional Combat Logic adds logic to most areas for stat upgrades, magic weapons, and other stuff like that. I figure pushing it to this rate is probably fine for now since if someone doesn't want it and there's no slots without it, they wouldn't mind taking one with it since they can just play as if it was off anyway.

I put the Grass Rando line there because I'm pretty sure you don't want it, but if you do want it, it's easier to adjust it. With grass rando on and local_fill set to default, it'll place 95% of a tunic grass rando world's filler items across tunic grass rando worlds. That 5% left is ~300 items, which will be mostly grass. And local_fill can be increased up to 98% to further reduce grass in the pool to ~120 items per world. But also it spams the fuck out of the text client and I could see that being annoying.
So, up to you there.