### PR TITLE
Super Metroid: ammo ranges

### DIFF
--- a/games/Ocarina of Time.yaml
+++ b/games/Ocarina of Time.yaml
@@ -9,6 +9,7 @@ Ocarina of Time:
   local_items:
     - Triforce Piece
     - Ice Trap
+    - Song of Time
 
   logic_rules: glitchless
   logic_no_night_tokens_without_suns_song: true

--- a/games/Super Metroid.yaml
+++ b/games/Super Metroid.yaml
@@ -33,18 +33,17 @@ Super Metroid:
   morph_placement: early
 
   missile_qty:
-    random-low: 10
-    random-high: 50
+    random-range-low-10-50: 10
+    random-range-high-10-50: 50
 
   super_qty:
-    random-low: 10
-    random-high: 50
+    random-range-low-15-40: 10
+    random-range-high-15-40: 50
     20: 50
 
   power_bomb_qty:
-    10: 50
-    random-low: 10
-    random-high: 50
+    random-range-low-10-20: 10
+    random-range-high-10-20: 50
 
   minor_qty: 100
 


### PR DESCRIPTION
Replaced ammo Random-lows and highs with ranges for a better end user experience,  extreme  amounts are less of a problem.
