### PR TITLE
Make Undernet Ranks either Local or Anywhere

### DIFF
--- a/games/MegaMan Battle Network 3.yaml
+++ b/games/MegaMan Battle Network 3.yaml
@@ -8,12 +8,10 @@ MegaMan Battle Network 3:
     full: 2
     
   extra_ranks:
-    '0': 3
-    '1': 5
-    '2': 4
-    '3': 2
+    Local: 3
+    Anywhere: 2
     
-  local_items: Progressive Undernet Rank
+  exclude_locations: Chocolate Shop 07
     
   triggers:
     - option_category: null
@@ -22,3 +20,23 @@ MegaMan Battle Network 3:
       options:
         null:
           name: MMBN3-{player}
+    
+    - option_category: MegaMan Battle Network 3
+      option_name: extra_ranks
+      option_result: Local
+      options:
+        MegaMan Battle Network 3:
+            extra_ranks:
+                '0': 5
+                '1': 3
+            +local_items: Progressive Undernet Rank
+            
+    - option_category: MegaMan Battle Network 3
+      option_name: extra_ranks
+      option_result: Anywhere
+      options:
+        MegaMan Battle Network 3:
+            extra_ranks:
+                '1': 1
+                '2': 4
+                '3': 3


### PR DESCRIPTION
Made it so Progressive Undernet Ranks can roll as local or non local, with Extra Ranks rolling at different values for each.

Also since Chocolate Shop 07 did not agree with local ranks that location is excluded until further notice