### PR TITLE
Lower Instrument Count Range

### DIFF
--- a/games/Links Awakening DX.yaml
+++ b/games/Links Awakening DX.yaml
@@ -8,7 +8,7 @@ Links Awakening DX:
     instruments: 5
     seashells: 3
   instrument_count:
-    random-range-6-8: 1
+    random-range-4-8: 1
   trendy_game:
     easy: 2
     normal: 5


### PR DESCRIPTION
6 is needlessly high and basically requires the same amount of items as all 8. 4 is a more reasonable "mid"-goal.