### PR TITLE
Update Key Weights on LADX

### DIFF
--- a/games/Links Awakening DX.yaml
+++ b/games/Links Awakening DX.yaml
@@ -15,16 +15,16 @@ Links Awakening DX:
     hard: 2
   shuffle_nightmare_keys:
     original_dungeon: 5
-    own_dungeons: 5
-    own_world: 5
-    any_world: 3
-    different_world: 1
+    own_dungeons: 3
+    own_world: 3
+    any_world: 4
+    different_world: 4
   shuffle_small_keys:
     original_dungeon: 5
-    own_dungeons: 5
-    own_world: 5
-    any_world: 3
-    different_world: 1
+    own_dungeons: 1
+    own_world: 1
+    any_world: 4
+    different_world: 4
   shuffle_maps:
     original_dungeon: 5
     own_dungeons: 5


### PR DESCRIPTION
My reasoning is that the current weights create a lot of empty "busywork-walking" from one dungeon to another. So you can get a key in Dungeon 1 to go to Dungeon 3 just to get a key for Dungeon 1 in Dungeon 3 and walk backwards.