### PR TITLE
[HK] Remove THK and Any goals

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -67,13 +67,11 @@ Hollow Knight:
   RemoveSpellUpgrades: 'false'
   StartLocation: king's_pass
   Goal:
-    any: 2
-    hollowknight: 3
     siblings: 3
     radiance: 3
+    grub_hunt: 2
     godhome: 0
     godhome_flower: 0
-    grub_hunt: 2
   GrubHuntGoal: random-range-middle-25-35
   WhitePalace: 
     exclude: 5

--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -67,7 +67,7 @@ Hollow Knight:
   RemoveSpellUpgrades: 'false'
   StartLocation: king's_pass
   Goal:
-    siblings: 3
+    siblings: 8
     radiance: 3
     grub_hunt: 2
     godhome: 0


### PR DESCRIPTION
Discussed around here: https://discord.com/channels/731205301247803413/1346222534034591867/1346238369096663131

THK goal is, skill-wise, identical to the Sealed Siblings goal; requiring the player to defeat The Hollow Knight within the Black Egg. However, THK requires three less items to goal (namely the forced-local King_Fragment, Queen_Fragment and Void_Heart). `any` goal is functionally an `all` goal, which means achieving the THK ending is still a viable goal. Additionally, it also activates Grub Hunt goal, allowing for potentially unexpected goalings.

Removing THK would not do much without also removing `any`, as `any` still allows for THK goals.