### PR TITLE
Saving Princess: add yaml

### DIFF
--- a/games/Saving Princess.yaml
+++ b/games/Saving Princess.yaml
@@ -1,0 +1,44 @@
+Saving Princess:
+  expanded_pool:
+    false: 30
+    true: 70
+
+  trap_chance:
+    0: 50
+    20: 50
+
+  death_link: false
+
+  instant_saving: true
+
+  sprint_availability:
+    always_available: 20
+    available_with_jacket: 80
+
+  cliff_weapon_upgrade:
+    never_upgraded: 10
+    always_upgraded: 45
+    vanilla: 45
+
+  ace_weapon_upgrade: always_upgraded
+
+  iframes_duration: 100
+
+  shake_intensity: 50
+
+  music_shuffle:
+    false: 70
+    true: 30
+
+  local_items:
+    - Ice Trap
+    - Shake Trap
+    - Ninja Trap
+
+  triggers:
+    - option_category: null
+      option_name: name
+      option_result: Player{player}
+      options:
+        null:
+          name: SavingP-{player}

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -48,6 +48,7 @@ game:
   Risk of Rain 2: 38
   Rogue Legacy: 30
   SMZ3: 25
+  Saving Princess: 4
   Secret of Evermore: 8
   Shivers: 8
   Slay the Spire: 25


### PR DESCRIPTION
For this yaml, I tried to assign weights based on how often I myself would like the options to appear, while leaving some room for less used ones to show up from time to time and spice things up.

The game is not very long, nor does it have many options, so the yaml is pretty basic. Many of them can be changed from within the game, pretty much everything that does not affect generation can be changed after the fact, so the surprise factor is going to be a bit of an honor system anyway.

Some options are always set to the same value:
- Ace is always set to upgraded. This is a pretty unpopular boss fight and his upgraded weapon makes it much more tolerable (as backwards as that sounds).
- IFrames and Screen Shake are set to 100% and 50% respectively, which seemed to be preferred by playtesters.
- Death link is always off. It CAN be enabled in-game.
- Traps are local only.

I was not sure what to set the default weight for Saving Princess itself to, feel free to change it to something else.