### PR TITLE
Add egg option to Witness yaml

### DIFF
--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -1,7 +1,7 @@
 Minecraft:
   goal:
     advancements: 1
-    eggs: 1
+    eggs: 2
   combat_difficulty:
     easy: 10
     normal: 20
@@ -25,7 +25,7 @@ Minecraft:
         Minecraft:
             advancement_goal: random-range-60-80
             required_bosses:
-                none: 30
+                none: 20
                 ender_dragon: 20
                 wither: 20
                 both: 10

--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -34,7 +34,7 @@ Minecraft:
       option_result: eggs
       options:
         Minecraft:
-            advancement_goal: random-range-40-60
+            advancement_goal: random-range-40-70
             egg-shards-required: random-range-10-17
             egg-shards-available: 20
             local_items: Dragon Egg Shard

--- a/games/Minecraft.yaml
+++ b/games/Minecraft.yaml
@@ -1,5 +1,7 @@
 Minecraft:
-  advancement_goal: random-range-30-80
+  goal:
+    advancements: 1
+    eggs: 1
   combat_difficulty:
     easy: 10
     normal: 20
@@ -11,15 +13,36 @@ Minecraft:
   include_postgame_advancements: off
   shuffle_structures: on
   structure_compasses: on
-  required_bosses: # Bosses which must be defeated to finish the game.
-    none: 50
-    ender_dragon: 25
-    wither: 25
-    both: 10
   exclude_locations:
     - Two by Two
     - Monsters Hunted
+
   triggers:
+    - option_category: Minecraft
+      option_name: goal
+      option_result: advancements
+      options:
+        Minecraft:
+            advancement_goal: random-range-60-80
+            required_bosses:
+                none: 30
+                ender_dragon: 20
+                wither: 20
+                both: 10
+    - option_category: Minecraft
+      option_name: goal
+      option_result: eggs
+      options:
+        Minecraft:
+            advancement_goal: random-range-40-60
+            egg-shards-required: random-range-10-17
+            egg-shards-available: 20
+            local_items: Dragon Egg Shard
+            required_bosses: # Bosses which must be defeated to finish the game.
+                none: 50
+                ender_dragon: 20
+                wither: 20
+                both: 10
     - option_category: null
       option_name: name
       option_result: Player{player}

--- a/games/The Witness.yaml
+++ b/games/The Witness.yaml
@@ -3,6 +3,11 @@ The Witness:
     sigma_normal: 75
     sigma_expert: 5
     umbra_variety: 20
+  easter_egg_hunt:
+    'off': 8
+    easy: 2
+    normal: 3
+    hard: 3
   shuffle_symbols: random
   shuffle_doors:
     off: 50

--- a/games/The Witness.yaml
+++ b/games/The Witness.yaml
@@ -3,11 +3,9 @@ The Witness:
     sigma_normal: 75
     sigma_expert: 5
     umbra_variety: 20
-  easter_egg_hunt:
-    'off': 8
-    easy: 2
-    normal: 3
-    hard: 3
+  is_it_April:
+    yes: 1
+    no: 0
   shuffle_symbols: random
   shuffle_doors:
     off: 50
@@ -70,6 +68,26 @@ The Witness:
   area_hint_percentage: random-range-30-70
   laser_hints: random
   triggers:
+    - option_category: The Witness
+      option_name: is_it_April
+      option_result: yes
+      options:
+        The Witness:
+          easter_egg_hunt:
+            'off': 2
+            easy: 2
+            normal: 4
+            hard: 1
+    - option_category: The Witness
+      option_name: is_it_April
+      option_result: no
+      options:
+        The Witness:
+          easter_egg_hunt:
+            'off': 10
+            easy: 1
+            normal: 2
+            hard: 0
     - option_category: The Witness
       option_name: shuffle_doors
       option_result: off


### PR DESCRIPTION
Currently it has a 50/50 of being enabled. If enabled, a somewhat arbitrary distribution of difficulties is given