### PR TITLE
Blasphemous: Only roll hard difficulty starting locations on hard difficulty

### DIFF
--- a/games/Blasphemous.yaml
+++ b/games/Blasphemous.yaml
@@ -16,9 +16,7 @@ Blasphemous:
     brotherhood: 8
     albero: 10
     convent: 3
-    knot_of_words: 3
     grievance: 2
-    rooftops: 1
   ending:
     any_ending: 4
     ending_c: 1
@@ -59,6 +57,19 @@ Blasphemous:
   local_items: [wounds]
   
   triggers:
+    - option_category: Blasphemous
+      option_name: difficulty
+      option_result: hard
+      options:
+        Blasphemous:
+          # knot_of_words and rooftops require hard difficulty or higher, so re-roll with them allowed.
+          starting_location:
+            brotherhood: 8
+            albero: 10
+            convent: 3
+            knot_of_words: 3
+            grievance: 2
+            rooftops: 1
     - option_category: Blasphemous
       option_name: starting_location
       option_result: brotherhood


### PR DESCRIPTION
Generation will fail in generate_early if a starting location that requires hard difficulty is picked but the rolled difficulty is easy or normal.

I did some test generations earlier with this change in place because Blasphemous kept crashing the generation otherwise.

The relevant bit of code in the Blasphemous world:
https://github.com/ArchipelagoMW/Archipelago/blob/0.6.1/worlds/blasphemous/__init__.py#L70-L73