### PR TITLE
Terraria: Raise Calamity weight, 1 in 5 -> 1 in 3

### DIFF
--- a/games/Terraria.yaml
+++ b/games/Terraria.yaml
@@ -1,8 +1,8 @@
 ﻿Terraria: 
   # Calamity is a mod for Terraria that adds many more bosses to the game.
-  # I suspect not many people will want to play it, but there will certainly be some that want to.
+  # Turns out it's more popular than I initially expected when writing this yaml. Maybe 1 in 3 is better.
   calamity:
-    'false': 4
+    'false': 2
     'true': 1
   # This is a very difficult secret seed in vanilla. It's probably too hard for a big async yaml.
   getfixedboi: 'false'


### PR DESCRIPTION
So it turns out more people want to play Calamity than expected. This simply raises the chance of Calamity rolling, surely 1 in 3 will be enough. (clueless)

This PR will be closed if generation succeeds with the old weight, as it would be better to get feedback on how quickly Calamity slots get taken up instead of just picking numbers and hoping for the best.