### PR TITLE
[meta] More Yacht Dice

### DIFF
--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -73,7 +73,7 @@ game:
   Undertale: 25
   VVVVVV: 12
   Wargroove: 6
-  Yacht Dice: 30
+  Yacht Dice: 100
   Yoshi's Island: 20
   Yu-Gi-Oh! 2006: 10
   Zillion: 3


### PR DESCRIPTION
The people demand more Yacht Dice, so we gotta deliver.

Seriously though, every Yacht Dice was picked in 8 hours. A weight of 30 is way too low, so let's set it to 100 instead.