### PR TITLE
[Civ VI] Excluded Boost Space Race and Urbanization

### DIFF
--- a/games/Civilization VI.yaml
+++ b/games/Civilization VI.yaml
@@ -21,3 +21,11 @@ Civilization VI:
       options:
         null:
           name: CivVI-{player}
+    - option_category: Civilization VI
+      option_name: boostsanity
+      option_result: 'true'
+      options:
+        Civilization VI:
+          exclude_locations: 
+            - BOOST_CIVIC_SPACE_RACE
+            - BOOST_CIVIC_URBANIZATION

--- a/games/Civilization VI.yaml
+++ b/games/Civilization VI.yaml
@@ -21,6 +21,7 @@ Civilization VI:
       options:
         null:
           name: CivVI-{player}
+    # Excluding Boosts That are missing Tech/Era requirements
     - option_category: Civilization VI
       option_name: boostsanity
       option_result: 'true'
@@ -28,6 +29,16 @@ Civilization VI:
         Civilization VI:
           exclude_locations: 
             - BOOST_CIVIC_SPACE_RACE
+            # building a space port
             - BOOST_CIVIC_URBANIZATION
+            # city with 10 pop
             - BOOST_TECH_ADVANCED_FLIGHT
+            # Biplanes requires oil
             - BOOST_TECH_REPLACEABLE_PARTS
+            # Line Infantry requires Military Engineering
+            - BOOST_TECH_SQUARE_RIGGING
+            # Musketman requires Military Engineering
+            - BOOST_TECH_NUCLEAR_FUSION
+            # Missing requirement for prog. Industrial zone x3
+            - BOOST_TECH_MILITARY_SCIENCE
+            # Knight requires Bronze Working

--- a/games/Civilization VI.yaml
+++ b/games/Civilization VI.yaml
@@ -29,3 +29,5 @@ Civilization VI:
           exclude_locations: 
             - BOOST_CIVIC_SPACE_RACE
             - BOOST_CIVIC_URBANIZATION
+            - BOOST_TECH_ADVANCED_FLIGHT
+            - BOOST_TECH_REPLACEABLE_PARTS


### PR DESCRIPTION
Boosts don't have an era set they should be achievable by.  So logic assumes these can be completed in the ancient era which they can't be.
There may be more but these locations have a chance to be needed to send via console, especially the space port which is maybe possible from modern era after 5 progressive eras.
Issue:
https://github.com/ArchipelagoMW/Archipelago/issues/5136