### PR TITLE
[SA2B] Fix mission distribution and Add Minigame Madness goal

### DIFF
--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -4,6 +4,12 @@ Sonic Adventure 2 Battle:
     Emeralds: 2
     minigame_madness: 2
   mission_shuffle: true
+  minigame_madness_requirement:
+    '4': 1
+    '5': 1
+  minigame_madness_minimum:
+    '5': 1
+    random-high: 1
   boss_rush_shuffle:
     vanilla: 2
     shuffled: 1

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -92,21 +92,36 @@ Sonic Adventure 2 Battle:
   sadx_music: sa2b
   narrator: random
   logic_difficulty: standard
-  speed_mission_count: random-range-2-4
-  speed_mission_2: true
-  speed_mission_3: true
-  speed_mission_4: true
-  speed_mission_5: false
-  mech_mission_count: random-range-1-3
-  mech_mission_2: true
-  mech_mission_3: true
-  mech_mission_4: true
-  mech_mission_5: false
-  hunt_mission_count: random-range-1-3
-  hunt_mission_2: true
-  hunt_mission_3: true
-  hunt_mission_4: false
-  hunt_mission_5: false
+  sonic_mission_count: random-range-2-4
+  sonic_mission_2: 'true'
+  sonic_mission_3: 'true'
+  sonic_mission_4: 'true'
+  sonic_mission_5: 'false'
+  shadow_mission_count: random-range-2-4
+  shadow_mission_2: 'true'
+  shadow_mission_3: 'true'
+  shadow_mission_4: 'true'
+  shadow_mission_5: 'false'
+  tails_mission_count: random-range-1-3
+  tails_mission_2: 'true'
+  tails_mission_3: 'true'
+  tails_mission_4: 'true'
+  tails_mission_5: 'false'
+  eggman_mission_count: random-range-1-3
+  eggman_mission_2: 'true'
+  eggman_mission_3: 'true'
+  eggman_mission_4: 'true'
+  eggman_mission_5: 'false'
+  knuckles_mission_count: random-range-1-3
+  knuckles_mission_2: 'true'
+  knuckles_mission_3: 'true'
+  knuckles_mission_4: 'false'
+  knuckles_mission_5: 'false'
+  rouge_mission_count: random-range-1-3
+  rouge_mission_2: 'true'
+  rouge_mission_3: 'true'
+  rouge_mission_4: 'false'
+  rouge_mission_5: 'false'
   kart_mission_count: random-range-1-2
   kart_mission_2: true
   kart_mission_3: false

--- a/games/Sonic Adventure 2 Battle.yaml
+++ b/games/Sonic Adventure 2 Battle.yaml
@@ -1,9 +1,8 @@
 Sonic Adventure 2 Battle:
   goal:
-    biolizard: 3
-    cannons_core_boss_rush: 1
-    boss_rush_chaos_emerald_hunt: 1
-    finalhazard_chaos_emerald_hunt: 1
+    CC: 3
+    Emeralds: 2
+    minigame_madness: 2
   mission_shuffle: true
   boss_rush_shuffle:
     vanilla: 2
@@ -132,7 +131,6 @@ Sonic Adventure 2 Battle:
   cannons_core_mission_3: false
   cannons_core_mission_4: false
   cannons_core_mission_5: false
-  local_items: Chaos Emeralds
   triggers:
     - option_category: null
       option_name: name
@@ -155,7 +153,6 @@ Sonic Adventure 2 Battle:
             chao_stats_frequency: 
                 '1': 1
                 '2': 1
-                '5': 1
     - option_category: Sonic Adventure 2 Battle
       option_name: chao_race_difficulty
       option_result: none
@@ -194,7 +191,7 @@ Sonic Adventure 2 Battle:
                 standard: 2
                 expert: 5
                 super_override: 3
-            chao_stats: '60'
+            chao_stats: '70'
             chao_stats_frequency: 
                 '1': 1
                 '2': 1
@@ -205,7 +202,7 @@ Sonic Adventure 2 Battle:
       options:
         Sonic Adventure 2 Battle:
             chao_karate_difficulty: expert
-            chao_stats: '60'
+            chao_stats: '70'
             chao_stats_frequency: 
                 '1': 1
                 '2': 1
@@ -216,7 +213,7 @@ Sonic Adventure 2 Battle:
       options:
         Sonic Adventure 2 Battle:
             chao_karate_difficulty: super
-            chao_stats: '70'
+            chao_stats: '80'
             chao_stats_frequency: 
                 '1': 1
                 '2': 1
@@ -242,7 +239,6 @@ Sonic Adventure 2 Battle:
             chao_stats_frequency: 
                 '1': 1
                 '2': 1
-                '5': 1
     - option_category: Sonic Adventure 2 Battle
       option_name: whistlesanity
       option_result: both_plus
@@ -250,3 +246,26 @@ Sonic Adventure 2 Battle:
         Sonic Adventure 2 Battle:
             animalsanity: 'true'
             whistlesanity: both
+    - option_category: Sonic Adventure 2 Battle
+      option_name: goal
+      option_result: CC
+      options:
+        Sonic Adventure 2 Battle:
+            goal:
+                biolizard: 3
+                cannons_core_boss_rush: 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: goal
+      option_result: Emeralds
+      options:
+        Sonic Adventure 2 Battle:
+            local_items: Chaos Emeralds
+            goal:
+                boss_rush_chaos_emerald_hunt: 1
+                finalhazard_chaos_emerald_hunt: 1
+    - option_category: Sonic Adventure 2 Battle
+      option_name: goal
+      option_result: minigame_madness
+      options:
+        Sonic Adventure 2 Battle:
+            local_items: Minigames


### PR DESCRIPTION
When someone updated the yaml to match 0.6.1 they did not update the missions properly. I personally submitted a custom SA2B last time so I didn't notice. This has allowed missions that were not enabled in previous Big Asyncs to be turned on. I have adjusted the yaml to be in line with what the previous settings were supposed to reflect