### PR TITLE
Increase chance of Terraria slots rolling Calamity

### DIFF
--- a/games/Terraria.yaml
+++ b/games/Terraria.yaml
@@ -1,8 +1,8 @@
 ﻿Terraria: 
   # Calamity is a mod for Terraria that adds many more bosses to the game.
-  # I suspect not many people will want to play it, but there will certainly be some that want to.
+  # Sorry, I was wrong. Calamity is actually in much higher demand than I thought.
   calamity:
-    'false': 4
+    'false': 1
     'true': 1
   # This is a very difficult secret seed in vanilla. It's probably too hard for a big async yaml.
   getfixedboi: 'false'


### PR DESCRIPTION
This increases the chances of each Terraria slot having Calamity mod, from 20% to 50%, as the old weight clearly was not enough.