### PR TITLE
Undertale: Only randomize LOVE/stats on genocide

### DIFF
--- a/games/Undertale.yaml
+++ b/games/Undertale.yaml
@@ -15,12 +15,6 @@ Undertale:
     5: 50
     7: 40
     10: 30
-  rando_love:
-    false: 50
-    true: 30
-  rando_stats:
-    false: 50
-    true: 30
   temy_include:
     false: 30
     true: 50
@@ -34,6 +28,21 @@ Undertale:
     false: 50
     true: 30
   triggers:
+    # Randomized LOVE and stats only do anything on the genocide route.
+    # Additionally, due to a bug, neutral route is affected in unintended ways if either of these are rolled.
+    # To avoid confusion, and the bug, only consider these options if genocide is rolled in the first place.
+    - option_category: Undertale
+      option_name: route_required
+      option_result: 'genocide'
+      options:
+        Undertale:
+          rando_love:
+            false: 50
+            true: 30
+          rando_stats:
+            false: 50
+            true: 30
+
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
`rando_love` and `rando_stats` do nothing when the route doesn't include genocide in the first place. At least, that's how it's supposed to work. Enabling either of these on a neutral route prevents the ability to gain LOVE or stats at all, which was confirmed to be a bug and I don't believe has been fixed since it was discovered.

Additionally, it's just to avoid confusion in general, much like how e.g. the Hat in Time yaml only has a chance to disable painting and ticket skips if a harder logic difficulty is rolled.