### PR TITLE
[Super Mario World] Banish Sfx Shuffle Singularity

### DIFF
--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -60,7 +60,6 @@ Super Mario World:
   sfx_shuffle:
     none: 6
     full: 3
-    singularity: 1
   mario_palette: random
   level_palette_shuffle:
     off: 3


### PR DESCRIPTION
Most people picking Super Mario World slots do not look at this option, and wouldn't know what can happen if it's enabled. It's a fun option for people editing their own yamls, but probably not well fit for an async with pregenerated options.