### PR TITLE
[TUNIC] Add Respawn Items to start_inventory

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -41,6 +41,9 @@ TUNIC:
     'false': 100
   local_items:
     - Questagons
+  start_inventory_from_pool:
+    Torch: 1
+    Dath Stone: 1
 
   triggers:
     - option_category: TUNIC


### PR DESCRIPTION
Adds the Torch and Dath Stone items to start_inventory_from_pool, as they are mainly QOL items and so I do not think they can actively harm any slot, and will definitely be useful for some.