### PR TITLE
[AsyncTools] + [The Witness] Create custom override for month sensitive options

### DIFF
--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 from colorama import Fore
+from datetime import date
 
 
 # Please don't look too closely at this code below. kthx -Phar
@@ -86,6 +87,10 @@ def main():
                     raise ValueError(f"Found {len(game_settings)} top-level keys in `./games/{game}.yaml`")
                 if game not in game_settings:
                     raise ValueError(f"Could not find `{game}` top-level key in `./games/{game}.yaml`")
+                
+                # Allow for certain yaml options to be set during a specific month. Note that this is set at yaml creation, not at generation start.
+                if "current_month" in game_settings[game]:
+                    game_settings[game]["current_month"] = date.today().strftime("%B")
 
                 mystery.update(game_settings)
         except FileNotFoundError:

--- a/games/The Witness.yaml
+++ b/games/The Witness.yaml
@@ -3,9 +3,7 @@ The Witness:
     sigma_normal: 75
     sigma_expert: 5
     umbra_variety: 20
-  is_it_April:
-    yes: 1
-    no: 0
+  current_month: 'January'
   shuffle_symbols: random
   shuffle_doors:
     off: 50
@@ -67,10 +65,14 @@ The Witness:
     experimental: 0  # Experimental has turned out to be perfectly stable & fun, but it adds more chaos and confusion than is healthy for the big public async.
   area_hint_percentage: random-range-30-70
   laser_hints: random
+  easter_egg_hunt:
+    'off': 10
+    easy: 1
+    normal: 2
   triggers:
     - option_category: The Witness
-      option_name: is_it_April
-      option_result: yes
+      option_name: current_month
+      option_result: April
       options:
         The Witness:
           easter_egg_hunt:
@@ -78,16 +80,6 @@ The Witness:
             easy: 2
             normal: 4
             hard: 1
-    - option_category: The Witness
-      option_name: is_it_April
-      option_result: no
-      options:
-        The Witness:
-          easter_egg_hunt:
-            'off': 10
-            easy: 1
-            normal: 2
-            hard: 0
     - option_category: The Witness
       option_name: shuffle_doors
       option_result: off


### PR DESCRIPTION
This change is an evolution of the previous "is it april" option that is now automated based on the month AsyncTools is run, as opposed to changing it manually.

The month can still be changed manually if desired in the option result of the trigger. It can be changed to match the current month for the April option, or changed to not match for the default option.