### PR TITLE
[The Witness] Standardize Laser randomization between goals

### DIFF
--- a/games/The Witness.yaml
+++ b/games/The Witness.yaml
@@ -107,6 +107,18 @@ The Witness:
         The Witness: 
           challenge_lasers: random-range-7-11
     - option_category: The Witness
+      option_name: victory_condition
+      option_result: elevator
+      options:  
+        The Witness: 
+          mountain_lasers: random-range-3-11
+    - option_category: The Witness
+      option_name: victory_condition
+      option_result: challenge
+      options:  
+        The Witness: 
+          challenge_lasers: random-range-3-11
+    - option_category: The Witness
       option_name: shuffle_EPs
       option_result: individual
       options:


### PR DESCRIPTION
This sets minimum lasers to 3 for Elevator and Challenge goals, so they don't instantly goal when symbol shuffle is disabled and doors are enabled. The goals do not need to match their box counterparts, as they are more involved than making it to the top of the mountain.

Panel Hunts are not affected by lasers, so they do not need to be changed.