### PR TITLE
[AsyncTools] Implement AP's method for matching games to files

### DIFF
--- a/GenerateMystery.py
+++ b/GenerateMystery.py
@@ -77,8 +77,9 @@ def main():
     # Merge together each game yaml into our mystery settings.
     for game in mystery["game"].keys():
         try:
-            print(f"Loading ./games/{game}.yaml...")
-            with open(f"games/{game}.yaml", encoding="utf-8-sig") as game_file:
+            safe_name = "".join(c for c in game if c not in '<>:/\\|?*')
+            print(f"Loading ./games/{safe_name}.yaml...")
+            with open(f"games/{safe_name}.yaml", encoding="utf-8-sig") as game_file:
                 game_settings: dict = yaml.unsafe_load(game_file)
 
                 # Ensure that game_settings only has one property which has the same name as the file.


### PR DESCRIPTION
Filenames have characters that are not allowed to be used that may be included in game titles, meaning that these characters have to be ignored when being matched in AP or AsyncTools. AP already implements this check, so this change just copies that check into AsyncTools.

The most common of these characters is the colon, which Jak and Daxter includes.