### PR TITLE
[Subnautica] Update yaml for 0.6.3 settings

### DIFF
--- a/games/Subnautica.yaml
+++ b/games/Subnautica.yaml
@@ -3,6 +3,7 @@ Subnautica:
   goal:
     launch: 3
     free: 2
+    infected: 1
   creature_scans:
     random-range-40-50: 1
   creature_scan_logic:
@@ -19,6 +20,7 @@ Subnautica:
     easy: 5
     normal: 4
     items_easy: 5
+  empty_tanks: true
   triggers:
     - option_category: null
       option_name: name


### PR DESCRIPTION
Okay so I assumed that the PR was merged and accidentally closed it, so I'm reopening it with the same changes

Empty_tanks true always, and readded infected goal because empty_tanks nerfs one's ability to cheese it (it's still cheesable it's just harder now)