### PR TITLE
[TUNIC] Remove torch from start inventory

### DIFF
--- a/games/TUNIC.yaml
+++ b/games/TUNIC.yaml
@@ -42,7 +42,6 @@ TUNIC:
   local_items:
     - Questagons
   start_inventory_from_pool:
-    Torch: 1
     Dath Stone: 1
 
   triggers:


### PR DESCRIPTION
I did not know that Torch did not exist separately from Dath Stone in the item pool. This didn't cause any gen errors but it is weird and so I am fixing it