### PR TITLE
SMW: Revert Donut Ghost House change and Carry prehint

### DIFF
--- a/games/Super Mario World.yaml
+++ b/games/Super Mario World.yaml
@@ -41,9 +41,7 @@ Super Mario World:
     simple: 2
     full: 2
     singularity: 1
-  swap_donut_gh_exits:
-    'true': 1
-    'false': 1
+  swap_donut_gh_exits: true
   junk_fill_percentage: 0
   trap_fill_percentage: random-low
   thwimp_trap_weight: random
@@ -81,12 +79,6 @@ Super Mario World:
         Super Mario World:
           early_climb: true
           swap_donut_gh_exits: false
-    - option_category: Super Mario World
-      option_name: swap_donut_gh_exits
-      option_result: false
-      options:
-        Super Mario World:
-          start_hints: Carry
     - option_category: Super Mario World
       option_name: blocksanity
       option_result: true


### PR DESCRIPTION
Pull request #346 is a mistake and should be reverted. I made a long rant about this in the helper channel. Here's a summary of the rant:

- The Carry prehint is a solution to a problem _caused by the original PR_, that being that you are forced to reach a secret exit to get past Donut Ghost House with unswapped exits, and most secret exits cannot be reached without Carry. This was done supposedly because being hard blocked by Carry and nothing else sounded like a good idea
- Being able to reach Vanilla Dome from sphere 1 is intentional, level shuffle deliberately places levels that are beatable with nothing until you reach Vanilla Dome
- You don't even full clear Donut Plains in sphere 1. As you cannot take most secret exits without Carry, you are forced to miss the levels on Donut Secret 1, Donut Secret 2, and Donut Ghost House, which make up almost half that world
- You are likely to get blocked in Vanilla Dome anyway until you get more items. This is only a difference of three levels, and leads to a far less restricted start as you have more paths you can take and more options to unblock you than just Carry
- Carry is already an extremely important item as it's required to take most secret exits, making it a hard requirement just to progress at all is unnecessary
- Carry is already a hard blocker in Forest of Illusion, as you cannot leave that world without taking at least one secret exit