### PR TITLE
modified whitelist options for Landstalker, Meritous, Zillion

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -506,6 +506,7 @@ Landstalker - The Treasures of King Nole:
     - Goal
     - Starting Region
     - Jewel Count
+    - Combat Difficulty
     - Hint Count
 Lingo:
     - Lingo
@@ -683,6 +684,7 @@ Meritous:
     - Name
     - Goal
     - Include PSI Keys
+    - Include Evolution Traps
     - Item cache cost scaling
 Muse Dash:
     - Muse Dash
@@ -1484,10 +1486,14 @@ Zillion:
     - Name
     - continues
     - floppies required
+    - early scope
     - jump levels
+    - gun levels
     - randomize alarms
     - max level
     - start character
+    - skill
+    - map generation
 Zork Grand Inquisitor:
     - Zork Grand Inquisitor
     - Locations


### PR DESCRIPTION
All of these options are randomized per the yamls for each, and are nice to know when selecting a slot.

### Landstalker
- Combat Difficulty

### Meritous
- Include Evolution Traps

### Zillion
- early scope
- gun levels
- skill
- map generation