### PR TITLE
Add Death Wish to A Hat in Time option whitelist

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -21,6 +21,7 @@ A Hat in Time:
     - Tasksanity Check Count
     - Exclude Tour Time Rift
     - Ship Shape Custom Task Goal
+    - Enable Death Wish
     - Shuffle Chapter 7
     - Baseball Bat
     - No Ticket Skips


### PR DESCRIPTION
While `EnableDeathWish` is initially set to false, there is a [trigger further down in the yaml](https://github.com/ArchipelagoMW/AsyncTools/blob/main/games/A%20Hat%20in%20Time.yaml#L424) which sets it to true with a very low chance. Players that don't want to play Death Wish don't want that kind of surprise.