### PR TITLE
Allow Zork and SADX to gen

### DIFF
--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -82,10 +82,10 @@ game:
   Yu-Gi-Oh! 2006: 8
   Zillion: 2
 
-  Zork: 5
+  Zork Grand Inquisitor: 5
   Frogmonster: 5
   Nine Sols: 20
   Outer Wilds: 20
   Ori and the Blind Forest: 20
   Luigi's Mansion: 30
-  SADX: 25
+  Sonic Adventure DX: 25


### PR DESCRIPTION
This probably works on Scooty's machine this is mostly just to fix an oversight on the repo.