### PR TITLE
Add Mario Kart Double Dash

### DIFF
--- a/games/Mario Kart Double Dash.yaml
+++ b/games/Mario Kart Double Dash.yaml
@@ -1,0 +1,102 @@
+﻿
+Mario Kart Double Dash:
+
+  goal:
+    all_cup_tour: 50
+    trophies: 30
+
+  trophy_requirement:
+    random-range-10-16: 50 
+
+  grand_prix_trophies:
+    'false': 50
+    'true': 50
+
+
+  logic_difficulty:
+    easy: 50 
+    normal: 50 
+
+  shuffle_extra_trophies: 0
+
+  time_trials:
+    disable: 50
+    basic: 50
+
+  course_shuffle:
+    shuffle_once: 50
+
+  all_cup_tour_length:
+    random-range-7-16: 50 
+
+  mirror_200cc:
+    'false': 50
+    'true': 50
+
+  shorter_courses:
+    'false': 50
+
+  custom_lap_counts:
+    Wario Colosseum: 2
+
+  items_for_everybody:
+    random-range-3-9: 50
+
+  items_per_character:
+    2: 50
+
+  start_items_per_character:
+    5: 30
+    4: 20
+    3: 10
+
+  kart_upgrades:
+
+    10: 10
+    20: 20
+    30: 20
+
+  speed_upgrades:
+    'true': 50
+
+  item_boxes_as_locations:
+    disabled: 50
+    
+  local_items:
+    Trophy
+    
+  triggers:
+    - option_category: null
+      option_name: name
+      option_result: Player{player}
+      options:
+        null:
+          name: MKDD-{player}
+          
+    - option_category: Mario Kart Double Dash
+      option_name:  start_items_per_character
+      option_result: 5
+      options:
+        Mario Kart Double Dash:
+          items_per_character: 2
+          
+    - option_category: Mario Kart Double Dash
+      option_name:  start_items_per_character
+      option_result: 4
+      options:
+        Mario Kart Double Dash:
+          items_per_character: 3
+          
+    - option_category: Mario Kart Double Dash
+      option_name:  start_items_per_character
+      option_result: 3
+      options:
+        Mario Kart Double Dash:
+          items_per_character: 4 
+          
+    - option_category: Mario Kart Double Dash
+      option_name:  grand_prix_trophies
+      option_result: 'false'
+      options:
+        Mario Kart Double Dash:
+          shuffle_extra_trophies: 16

--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -91,3 +91,4 @@ game:
   Ori and the Blind Forest: 20
   Luigi's Mansion: 30
   Sonic Adventure DX: 25
+  Mario Kart Double Dash: 20


### PR DESCRIPTION
I'm a bit disappointed in the lack of Shorter Courses and having all 16 courses be included in the all cup tour, but given that the Big Async is a month long event, having a bit of a longer goal isn't that much of a problem.

The full three lap all cup tour tends to take over half an hour and will need to be reattempted for each failed attempt (though it is very easy to not fail if you're in go mode)

I haven't tried 200cc myself so I can't comment on it.

Other than those things I don't have any issues with the YAML. I'll just go ahead and submit what Bunk posted in the Double Dash channel, and I decided to give DD a weight similar to Outer Wilds.