### PR TITLE
[Sonic Adventure DX] Disable Emblem Gating

### DIFF
--- a/games/Sonic Adventure DX.yaml
+++ b/games/Sonic Adventure DX.yaml
@@ -4,7 +4,6 @@ Sonic Adventure DX:
     normal_logic: 50
 
   gating_mode:
-    emblems_gating: 50
     key_items_gating: 50
 
   goal_requires_levels:


### PR DESCRIPTION
Due to doing tests on 1.2.1 as opposed to the version submitted to us, Emblem Gating appears to be unstable and may cause generation issues. Bunk has suggested to disable it for this session.