### PR TITLE
Remove local Letter from Pokemon Emerald yaml

### DIFF
--- a/games/Pokemon Emerald.yaml
+++ b/games/Pokemon Emerald.yaml
@@ -199,7 +199,7 @@ Pokemon Emerald:
     true: 20
   death_link: false
   enable_wonder_trading: true
-  local_items: Letter
+  local_items: []
 
   triggers:
     # Blacklist wild legendaries


### PR DESCRIPTION
Local letter removed avenues for Emerald players to escape Dewford Jail as there are other means of doing so that were still distributed through the multiworld.  Letter unwalls were byfar the rarest means of escaping Dewford due to this.