### PR TITLE
[TLoZ] Local silvers

### DIFF
--- a/games/The Legend of Zelda.yaml
+++ b/games/The Legend of Zelda.yaml
@@ -1,5 +1,5 @@
 The Legend of Zelda:
-  local_items: [Triforce Fragment]
+  local_items: [Triforce Fragment, Silver Arrow]
   ExpandedPool:
     false: 20
     true: 80


### PR DESCRIPTION
The Silver Arrow doesn't unlock any check in Zelda 1, and adds a unnecessary wait at the end of the seed to be in go mode. I feel like forcing it to be local would solve that issue.