### PR TITLE
[Emerald] Un-local the Letter

### DIFF
--- a/games/Pokemon Emerald.yaml
+++ b/games/Pokemon Emerald.yaml
@@ -199,7 +199,6 @@ Pokemon Emerald:
     true: 20
   death_link: false
   enable_wonder_trading: true
-  local_items: Letter
 
   triggers:
     # Blacklist wild legendaries


### PR DESCRIPTION
After feedback, this was Not A Good Move. It *might* have gone over better if people actually read changelogs, but without an Early Letter option, this feels more restrictive to people.

(Note for pedants: This does not *force* the Letter to be non-local, just makes it not forced local again like it was.)