### PR TITLE
Force keys local in case of locked paintings in Super Mario 64.yaml

### DIFF
--- a/games/Super Mario 64.yaml
+++ b/games/Super Mario 64.yaml
@@ -52,6 +52,15 @@ Super Mario 64:
       options:
         Super Mario 64:
           progressive_keys: false
+    - option_category: Super Mario 64
+      option_name: enable_locked_paintings
+      option_result: true
+      options:
+        Super Mario 64:
+          local_items:
+            - Progressive Key
+            - Basement Key
+            - Second Floor Key
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
Added a trigger to force progressive keys, basement keys, and second floor keys local if the painting locked feature rolls for a certain world.