### PR TITLE
[Emerald] Increase weight for non-Surf Dewford Keys

### DIFF
--- a/games/Pokemon Emerald.yaml
+++ b/games/Pokemon Emerald.yaml
@@ -174,11 +174,11 @@ Pokemon Emerald:
     true: 70
   remove_roadblocks: []
   extra_boulders:
-    false: 35
-    true: 65
+    false: 25
+    true: 75
   extra_bumpy_slope:
-    false: 35
-    true: 65
+    false: 25
+    true: 75
   modify_118:
     false: 35
     true: 65


### PR DESCRIPTION
Increases the weight of Extra Bumpy Slope and Extra Boulders by roughly 10% each, which allow the Acro Bike and HM04+Heat Badge to be unwalls during Dewford Jail.