### PR TITLE
SAWS: tweak tech costs

### DIFF
--- a/games/Factorio - Space Age Without Space.yaml
+++ b/games/Factorio - Space Age Without Space.yaml
@@ -29,7 +29,9 @@
     low: 40
     middle: 20
     high: 10
-  tech_cost_mix: 100
+  tech_cost_mix:
+    100: 1
+    random: 4
   ramping_tech_costs: 'false'
   silo: randomize_recipe
   satellite: randomize_recipe

--- a/games/Factorio - Space Age Without Space.yaml
+++ b/games/Factorio - Space Age Without Space.yaml
@@ -23,7 +23,7 @@
     trees: 20
     choices: 20
   min_tech_cost: 5
-  max_tech_cost: 500
+  max_tech_cost: random-range-low-100-10000
   tech_cost_distribution:
     even: 100
     low: 40

--- a/games/Factorio - Space Age Without Space.yaml
+++ b/games/Factorio - Space Age Without Space.yaml
@@ -32,7 +32,9 @@
   tech_cost_mix:
     100: 1
     random: 4
-  ramping_tech_costs: 'false'
+  ramping_tech_costs:
+    true: 1
+    false: 4
   silo: randomize_recipe
   satellite: randomize_recipe
   free_samples: stack

--- a/games/Factorio - Space Age Without Space.yaml
+++ b/games/Factorio - Space Age Without Space.yaml
@@ -23,7 +23,7 @@
     trees: 20
     choices: 20
   min_tech_cost: 5
-  max_tech_cost: random-range-low-100-10000
+  max_tech_cost: random-range-low-200-10000
   tech_cost_distribution:
     even: 100
     low: 40
@@ -34,7 +34,7 @@
     random: 4
   ramping_tech_costs:
     true: 1
-    false: 4
+    false: 1
   silo: randomize_recipe
   satellite: randomize_recipe
   free_samples: stack
@@ -204,6 +204,12 @@
   energy_link: 'true'
     
   triggers:
+    - option_category: Factorio - Space Age Without Space
+      option_name: ramping_tech_costs
+      option_result: true
+      options:
+        Factorio - Space Age Without Space:
+          max_tech_cost: random-range-1000-5000
     - option_category: null
       option_name: name
       option_result: Player{player}


### PR DESCRIPTION
- `max_tech_cost`: was `500`, now ~~`random-range-low-100-10000` to match base Factorio~~ `random-range-low-200-10000` on non-ramping slots, `random-range-1000-5000` on ramping ones
- `tech_cost_mix`: was `100`, now 20% `100`, 80% `random`; base Factorio is `random`
- `ramping_tech_costs`: was `false`, now ~~20% `true`, 80% `false` to match base Factorio~~ 50/50

~~Not 100% sure I like the ramping costs being 80% `false`, but going to what base Factorio does is probably at least a decent starting point.~~