### PR TITLE
[SC2] update yaml

### DIFF
--- a/games/Starcraft 2.yaml
+++ b/games/Starcraft 2.yaml
@@ -3,12 +3,14 @@ Starcraft 2:
     # Overarching trigger, selecting one of these formats
     # Each format should consistently roll the exact amount of missions specified
     # This should provide a way to easily identify them in the options table
-    standard: 25
-    # 50 missions, Grid/Golden Path/Hopscotch/Blitz
-    challenge: 15
-    # 40 missions, any_unit logic, reduced checks, always hard/brutal, trap items
-    free_to_play: 20
-    # 35 missions, only f2p (WoL, Prophecy, Prologue)
+    standard: 18
+    # 60 missions, Grid/Golden Path/Hopscotch/Blitz
+    challenge: 10
+    # 50 missions, any_unit logic, reduced checks, always hard/brutal, trap items
+    free_to_play: 13
+    # 45 missions, only f2p (WoL, Prophecy, Prologue)
+    no_nco: 13
+    # 55 missions, exclude NCO (apparently many people only own the main campaigns)
     single_race_terran: 5
     single_race_zerg: 5
     single_race_protoss: 5
@@ -18,16 +20,16 @@ Starcraft 2:
     # 83 missions, vanilla/vanilla shuffled
     # race-swaps disabled, vanilla-like experience
     # will always have progressive keys to prevent huge early releases
-    full_campaign: 5
-    # 195 missions, reduced checks, reduced effects of fillers 
+    full_campaign: 7
+    # 195 missions, reduced checks, reduced effects of fillers
     # Designed to roll with all/most items, but not have too many fillers beyond that
     # will always have progressive keys to prevent huge early releases
-    custom_big_async_logo: 5
+    custom_big_async_logo: 7
     # 105 missions, custom mission order
     # canvas layout representing a Big Async logo
-    custom_swapped_campaigns: 5
-    # 42 missions, custom mission order
-    # 6 columns of 7 missions each, each column representing one campaign with swapped race
+    custom_swapped_campaigns: 7
+    # 54 missions, custom mission order
+    # 6 columns of 9 missions each, each column representing one campaign with swapped race
 
 
   game_difficulty:
@@ -57,23 +59,20 @@ Starcraft 2:
   mercenary_highlanders: true
   difficulty_curve: standard
   mission_race_balancing: semi_balanced
-  vanilla_locations: enabled
-  extra_locations: enabled
-  challenge_locations: enabled
 
   # These options will sometimes be overridden by a trigger
-  # size should always be changed by a trigger. 
+  # size should always be changed by a trigger.
   # If it ends up with 10, something went wrong
-  maximum_campaign_size: 10  
-  required_tactics: 
+  maximum_campaign_size: 10
+  required_tactics:
     standard: 50
     advanced: 50
   mission_order:
     # standard distribution for mission orders
     grid: 30
-    golden_path: 40
-    hopscotch: 20
-    Blitz: 10
+    golden_path: 35
+    hopscotch: 15
+    Blitz: 20
   enabled_campaigns:
     - 'Wings of Liberty'
     - 'Prophecy'
@@ -108,6 +107,9 @@ Starcraft 2:
   kerrigan_level_item_distribution: vanilla
   kerrigan_primal_status: item
   start_primary_abilities: 0
+  vanilla_locations: enabled
+  extra_locations: enabled
+  challenge_locations: enabled
   mastery_locations: filler
   speedrun_locations: filler
   exclude_very_hard_missions: false
@@ -122,9 +124,9 @@ Starcraft 2:
   kerrigan_max_active_abilities: 12
   kerrigan_max_passive_abilities: 5
   # key mode will always be overridden by triggers, and always use progressive options
-  # smaller slots <= 50 missions will have 20% chance for no keys
+  # smaller slots <= 60 missions will have 20% chance for no keys
   # bigger slots will always have keys
-  key_mode: disabled  
+  key_mode: disabled
   victory_cache: 0
   filler_percentage: 0
   minerals_per_item: 10
@@ -147,8 +149,9 @@ Starcraft 2:
     Reduced Upgrade Research Cost: 1
 
   full_campaign_mission_order: 0 # needs to exist, so we can override it with triggers
+  locked_items: {}
 
-  custom_mission_order: 
+  custom_mission_order:
     # needs to exist, so we can override it with triggers
     # fill with minimum values to be valid
     Empty:
@@ -164,14 +167,14 @@ Starcraft 2:
     # logic will be remade, until then exclude this for safety
     # gets unexcluded for full campaign
 
-  triggers: 
+  triggers:
     # Game formats
     - option_category: Starcraft 2
       option_name: game_format
       option_result: standard
       options:
         Starcraft 2:
-          maximum_campaign_size: 50
+          maximum_campaign_size: 60
           enable_race_swap: pick_one
 
     - option_category: Starcraft 2
@@ -179,32 +182,36 @@ Starcraft 2:
       option_result: challenge
       options:
         Starcraft 2:
-          maximum_campaign_size: 40
+          maximum_campaign_size: 50
           enable_race_swap: pick_one
           required_tactics: any_units
-          game_difficulty: 
-              hard: 40
-              brutal: 60
+          game_difficulty:
+            hard: 40
+            brutal: 60
+          locked_items: # any_unit logic doesn't work well with upgrades.
+            Terran Generic Upgrades: 3 # So just lock them to level 3
+            Zerg Generic Upgrades: 3
+            Protoss Generic Upgrades: 3
           maximum_supply_reduction_per_item: 10
-          lowest_maximum_supply: 200
+          lowest_maximum_supply: 180
           filler_items_distribution:
-              1 Kerrigan Level: 0
-              Additional Maximum Supply: 10
-              Additional Starting Minerals: 10
-              Additional Starting Supply: 10
-              Additional Starting Vespene: 10
-              Decreased Maximum Supply: 1
-              Increased Building Construction Speed: 10
-              Increased Shield Regeneration: 10
-              Increased Upgrade Research Speed: 10
-              Reduced Upgrade Research Cost: 10
+            1 Kerrigan Level: 0
+            Additional Maximum Supply: 10
+            Additional Starting Minerals: 10
+            Additional Starting Supply: 10
+            Additional Starting Vespene: 10
+            Decreased Maximum Supply: 2
+            Increased Building Construction Speed: 10
+            Increased Shield Regeneration: 10
+            Increased Upgrade Research Speed: 10
+            Reduced Upgrade Research Cost: 10
 
     - option_category: Starcraft 2
       option_name: game_format
       option_result: free_to_play
       options:
         Starcraft 2:
-          maximum_campaign_size: 35
+          maximum_campaign_size: 45
           enabled_campaigns: !!set
             ? 'Wings of Liberty'
             ? 'Prophecy'
@@ -213,10 +220,24 @@ Starcraft 2:
 
     - option_category: Starcraft 2
       option_name: game_format
+      option_result: no_nco
+      options:
+        Starcraft 2:
+          maximum_campaign_size: 55
+          enabled_campaigns: !!set
+            ? 'Wings of Liberty'
+            ? 'Prophecy'
+            ? 'Heart of the Swarm'
+            ? 'Whispers of Oblivion (Legacy of the Void: Prologue)'
+            ? 'Legacy of the Void'
+            ? 'Into the Void (Legacy of the Void: Epilogue)'
+
+    - option_category: Starcraft 2
+      option_name: game_format
       option_result: single_race_terran
       options:
         Starcraft 2:
-          maximum_campaign_size: 25
+          maximum_campaign_size: 30
           enable_race_swap: pick_one
           selected_races: !!set
             ? 'Terran'
@@ -227,7 +248,7 @@ Starcraft 2:
       option_result: single_race_zerg
       options:
         Starcraft 2:
-          maximum_campaign_size: 25
+          maximum_campaign_size: 30
           enable_race_swap: pick_one
           selected_races: !!set
             ? 'Zerg'
@@ -237,7 +258,7 @@ Starcraft 2:
       option_result: single_race_protoss
       options:
         Starcraft 2:
-          maximum_campaign_size: 25
+          maximum_campaign_size: 30
           enable_race_swap: pick_one
           selected_races: !!set
             ? 'Protoss'
@@ -252,6 +273,14 @@ Starcraft 2:
           mission_order: vanilla
           enable_race_swap: disabled
           excluded_missions: []  # un-do all exclusions
+          # big mission order, reduce some locations
+          challenge_locations: half_chance
+          mastery_locations: disabled
+          key_mode:
+            # always force keys
+            progressive_missions: 40
+            progressive_questlines: 30
+            progressive_per_questline: 30
 
     - option_category: Starcraft 2
       option_name: game_format
@@ -262,6 +291,15 @@ Starcraft 2:
           mission_order: vanilla_shuffled
           enable_race_swap: pick_one
           excluded_missions: []  # un-do all exclusions
+          # big mission order, reduce some locations
+          extra_locations: half_chance
+          challenge_locations: half_chance
+          mastery_locations: disabled
+          key_mode:
+            # always force keys
+            progressive_missions: 40
+            progressive_questlines: 30
+            progressive_per_questline: 30
 
     - option_category: Starcraft 2
       option_name: game_format
@@ -269,42 +307,26 @@ Starcraft 2:
       options:
         Starcraft 2:
           maximum_campaign_size: 195
-          full_campaign_mission_order: 
-            # always force keys to prevent huge early releases
-            grid_keys: 40
-            golden_path_keys: 40 
-            blitz_keys: 20 
-            # don't include hopscotch here
           excluded_missions: []  # un-do all exclusions
+          # biggest mission order, reduce locations
+          vanilla_locations: half_chance
+          extra_locations: half_chance
+          challenge_locations: half_chance
+          mastery_locations: disabled
+          full_campaign_mission_order:
+            # always force keys
+            grid_keys: 40
+            golden_path_keys: 40
+            blitz_keys: 20
+            # don't include hopscotch here
 
     # Match key mode to mission orders
-    - option_category: Starcraft 2
-      option_name: mission_order
-      option_result: vanilla
-      options:
-        Starcraft 2:
-          enable_race_swap: disabled
-          key_mode: 
-            progressive_missions: 40
-            progressive_questlines: 30
-            progressive_per_questline: 30
-            # only used for big  mission orders, so always force keys
-    - option_category: Starcraft 2
-      option_name: mission_order
-      option_result: vanilla_shuffled
-      options:
-        Starcraft 2:
-          key_mode: 
-            progressive_missions: 40
-            progressive_questlines: 30
-            progressive_per_questline: 30
-            # only used for big  mission orders, so always force keys
     - option_category: Starcraft 2
       option_name: mission_order
       option_result: grid
       options:
         Starcraft 2:
-          key_mode: 
+          key_mode:
             progressive_missions: 80
             disabled: 20
     - option_category: Starcraft 2
@@ -312,7 +334,7 @@ Starcraft 2:
       option_result: golden_path
       options:
         Starcraft 2:
-          key_mode: 
+          key_mode:
             progressive_missions: 30
             progressive_questlines: 20
             progressive_per_questline: 30
@@ -322,7 +344,7 @@ Starcraft 2:
       option_result: hopscotch
       options:
         Starcraft 2:
-          key_mode: 
+          key_mode:
             progressive_missions: 80
             disabled: 20
     - option_category: Starcraft 2
@@ -330,7 +352,7 @@ Starcraft 2:
       option_result: blitz
       options:
         Starcraft 2:
-          key_mode: 
+          key_mode:
             progressive_missions: 80
             disabled: 20
 
@@ -446,14 +468,14 @@ Starcraft 2:
           maximum_supply_per_item: 2
 
     # brutal: upgrades need research, stricter limits on upgrades per unit
-    # Kerrigan disabled, limits on SoA, war council nerfs, more forced fillers, trap items
+    # Kerrigan disabled, limits on SoA, war council nerfs, more forced fillers
     - option_category: Starcraft 2
       option_name: game_difficulty
       option_result: brutal
       options:
         Starcraft 2:
           starter_unit: off
-          difficulty_damage_modifier: 
+          difficulty_damage_modifier:
             false: 50
             true: 50
           min_number_of_upgrades: 1
@@ -480,7 +502,7 @@ Starcraft 2:
           starting_supply_per_item: 2
           maximum_supply_per_item: 2
 
-    # very big mission orders, always force keys to prevent huge early release
+    # match key mode to mission order for full campaign
     - option_category: Starcraft 2
       option_name: full_campaign_mission_order
       option_result: grid_keys
@@ -501,7 +523,7 @@ Starcraft 2:
       options:
         Starcraft 2:
           mission_order: golden_path
-          key_mode: 
+          key_mode:
             progressive_missions: 50
             progressive_per_questline: 50
 
@@ -513,7 +535,15 @@ Starcraft 2:
         Starcraft 2:
           maximum_campaign_size: 105  # has no effect, just for clarity
           mission_order: custom
-          key_mode: progressive_per_questline  # has no effect, but the keys function similarly 
+          # big mission order, reduce some locations
+          extra_locations: half_chance
+          challenge_locations: half_chance
+          mastery_locations: disabled
+          locked_items: # lock 2 additional redundant keys each
+            "Progressive Key #1": 15 # 13 keys required
+            "Progressive Key #2": 19 # 17 keys required
+            "Progressive Key #3": 15 # 13 keys required
+          key_mode: progressive_per_questline  # has no effect, but the keys function similarly
           custom_mission_order:
             The Big Async:
               type: canvas
@@ -534,12 +564,12 @@ Starcraft 2:
                 - 'ttt  p t z zzp  '  # 13
                 - 't tp p t z  zp  '  # 14
                 - 'T T P  T Z  Z PP'  # 15
-                
+
                 # 105 missions total
                 # Terran: I + A + Y = 37 missions
                 # Zerg: B + N = 35 missions
                 # Protoss: G + S + C = 33 missions
-                
+
               jump_distance_orthogonal: 2
               jump_distance_diagonal: 1
               missions:
@@ -563,28 +593,28 @@ Starcraft 2:
                   mission_pool:
                     - Terran Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 2
                 - index:
                     - group(z)
                   mission_pool:
                     - Zerg Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 1
                 - index:
                     - group(p)
                   mission_pool:
                     - Protoss Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 3
                 - index:
                     - group(T)
                   mission_pool:
                     - Terran Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 2
                   difficulty: very_hard
                   exit: true
@@ -594,7 +624,7 @@ Starcraft 2:
                   mission_pool:
                     - Zerg Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 1
                   difficulty: very_hard
                   exit: true
@@ -604,7 +634,7 @@ Starcraft 2:
                   mission_pool:
                     - Protoss Missions
                   entry_rules:
-                  - items: 
+                  - items:
                         Progressive Key: 3
                   difficulty: very_hard
                   exit: true
@@ -616,97 +646,104 @@ Starcraft 2:
       option_result: custom_swapped_campaigns
       options:
         Starcraft 2:
-          maximum_campaign_size: 42  # has no effect, just for clarity
-          enable_race_swap: pick_one_non_vanilla
+          maximum_campaign_size: 54  # has no effect, just for clarity
+          enable_race_swap: shuffle_all_non_vanilla
           mission_order: custom
           kerrigan_presence: not_present  # Kerrigan currently cannot appear in forced race swaps
           spear_of_adun_presence: protoss  # override vanilla setting, as that would not work in forced race swaps
           key_mode: progressive_per_questline  # has no effect, but the keys function similarly
+          locked_items: # lock 1 additional redundant key each
+            "Progressive Key #1": 5 # 4 keys required
+            "Progressive Key #2": 5
+            "Progressive Key #3": 5
+            "Progressive Key #4": 5
+            "Progressive Key #5": 5
+            "Progressive Key #6": 5
           custom_mission_order:
             Swap of the Race:
-                #  6 columns times 7 missions = 42 missions
+                #  6 columns times 9 missions = 54 missions
                 Wings of the Swarm:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - Terran Missions
                         - ^ HotS Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 1  # each key unlocks 2 missions
-                        - index: [6]
+                        - index: [8]
                           goal: true
                 Heart of the Void:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - LotV Missions
                         - Prophecy Missions
                         - Prologue Missions
                         - ^ Zerg Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 2
-                        - index: [6]
+                        - index: [8]
                           goal: true
                 Legacy of Liberty:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - Protoss Missions
                         - ^ WoL Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 3
-                        - index: [6]
+                        - index: [8]
                           goal: true
                 Wings of the Void:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - LotV Missions
                         - Prophecy Missions
                         - Prologue Missions
                         - ^ Terran Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 4
-                        - index: [6]
+                        - index: [8]
                           goal: true
                 Heart of Liberty:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - Zerg Missions
                         - ^ WoL Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 5
-                        - index: [6]
+                        - index: [8]
                           goal: true
                 Legacy of the Swarm:
-                    size: 7
+                    size: 9
                     type: column
-                    mission_pool: 
+                    mission_pool:
                         - Protoss Missions
                         - ^ HotS Missions
-                    missions: 
-                        - index: [1, 3, 5]
+                    missions:
+                        - index: [1, 3, 5, 7]
                           entry_rules:
-                            - items: 
+                            - items:
                                 Progressive Key: 6
-                        - index: [6]
-                          goal: true         
+                        - index: [8]
+                          goal: true
 
     # long games - reduce effect of fillers
     - option_category: Starcraft 2
@@ -723,7 +760,7 @@ Starcraft 2:
       option_name: maximum_campaign_size
       option_result: 83  # Game Format: Vanilla
       options:
-        Starcraft 2:          
+        Starcraft 2:
           minerals_per_item: 8
           vespene_per_item: 8
           starting_supply_per_item: 2
@@ -733,7 +770,7 @@ Starcraft 2:
       option_name: maximum_campaign_size
       option_result: 105  # Game Format: Custom Big Async Canvas
       options:
-        Starcraft 2:          
+        Starcraft 2:
           minerals_per_item: 8
           vespene_per_item: 8
           starting_supply_per_item: 2

--- a/games/Starcraft 2.yaml
+++ b/games/Starcraft 2.yaml
@@ -14,7 +14,7 @@ Starcraft 2:
     single_race_terran: 5
     single_race_zerg: 5
     single_race_protoss: 5
-    # 25 missions, shorter mission order, only one race
+    # 30 missions, shorter mission order, only one race
     vanilla: 5
     vanilla_shuffled: 5
     # 83 missions, vanilla/vanilla shuffled


### PR DESCRIPTION
Updates to the SC2 yaml, based on observed issues and player feedback.

## Add new slot with no NCO ##
Apparently, many players own the original campaigns, but have never bought the Nova Covert Ops mission packs. We had multiple requests for a slot, that doesn't include NCO but is not limited only to the free to play campaigns.

## Increase weights for bigger slots ##
Traditionally, bigger slots are in higher demand for the big async. We don't want to over-do it, but the weights for bigger slots get a slight increase.

## Bigger small/medium slots ##
The smaller slots did feel a little short, and especially the challenge/any_unit slots had trouble getting enough checks for a good enough composition. Increasing the mission count for smaller slots by roughly 20% across the board.

## Reduced locations for bigger slots ##
This was planned from the start, but never made it into the yaml. By reducing the checks per mission for bigger slots, we hope to reduce excessive filler items and better balance the big slots against other games.

## Weapon & Armor upgrades
Challenge slots on any_units logic do not handle W/A upgrades very well. They are very important to keep up with the enemies in harder missions, so this is a logic issue we will address in a future update. Fix this for now by forcing enough W/A upgrades into the pool.

## Reduce Hopscotch, increase Blitz ##
For mission orders, Hopscotch has received negative feedback for being too linear and restrictive, while Blitz was received more positively, despite being at a much lower weight. Reducing Hopscotch and increasing Blitz weights.

## Redundant Keys ##
This is a planned option for a future SC2 version, but some slots can already take advantage of it. 
- Big Async logo slots now add 2 additional redundant copies of each key into the pool
- Swap of the Race slots now add 1 additional redundant copy of each key

Additionally, there is some formatting changes, and the file was saved with an option to cull trailing whitespaces, which causes some of the differences.

----

This yaml was tested by generating several 50 mission multiworlds. No generation failure of any kind was observed.