### PR TITLE
Weight Adjustment

### DIFF
--- a/games/__meta__.yaml
+++ b/games/__meta__.yaml
@@ -5,117 +5,117 @@ requires:
 
 # Define your game here!
 game:
-  A Hat in Time: 40
-  A Link to the Past: 60
-  A Short Hike: 30
-  Adventure: 3
-  Aquaria: 5
-  Blasphemous: 10
-  Bomb Rush Cyberfunk: 10
-  Bumper Stickers: 10
-  Castlevania 64: 5
-  Castlevania - Circle of the Moon: 10
-  Celeste (Open World): 65
-  Celeste 64: 20
+  A Hat in Time: 64
+  A Link to the Past: 58
+  A Short Hike: 27
+  Adventure: 2
+  Aquaria: 2
+  Blasphemous: 9
+  Bomb Rush Cyberfunk: 8
+  Bumper Stickers: 7
+  Castlevania 64: 3
+  Castlevania - Circle of the Moon: 8
+  Celeste (Open World): 100
+  Celeste 64: 21
   ChecksFinder: 15
-  Choo-Choo Charles: 12
-  Civilization VI: 20
-  Dark Souls III: 25
-  DLCQuest: 30
-  Donkey Kong Country 3: 10
-  DOOM 1993: 25
-  DOOM II: 15
+  Choo-Choo Charles: 9
+  Civilization VI: 15
+  Dark Souls III: 26
+  DLCQuest: 21
+  Donkey Kong Country 3: 9
+  DOOM 1993: 23
+  DOOM II: 11
   EarthBound: 23
-  Factorio: 20
-  Faxanadu: 5
-  Final Fantasy Mystic Quest: 20
-  Heretic: 5
-  Hollow Knight: 88
-  Hylics 2: 3
-  Inscryption: 25
-  'Jak and Daxter: The Precursor Legacy': 25
-  Kingdom Hearts: 35
-  Kingdom Hearts 2: 55
-  Kirby's Dream Land 3: 15
-  Landstalker - The Treasures of King Nole: 4
-  Lingo: 30
-  Links Awakening DX: 40
-  Lufia II Ancient Cave: 6
-  Mario & Luigi Superstar Saga: 35
-  MegaMan Battle Network 3: 12
-  Mega Man 2: 15
-  Mega Man 3: 15
-  Meritous: 4
-  Muse Dash: 32
-  Noita: 7
-  Ocarina of Time: 60
-  Overcooked! 2: 12
-  Paint: 25
-  Pokemon Emerald: 85
-  Pokemon Red and Blue: 40
-  Raft: 4
-  Risk of Rain 2: 38
-  SMZ3: 25
-  Satisfactory: 15
-  Saving Princess: 4
-  Secret of Evermore: 8
-  shapez: 25
-  Shivers: 6
-  Sonic Adventure 2 Battle: 40
-  Starcraft 2: 55
-  Stardew Valley: 50
-  Subnautica: 15
-  Super Mario 64: 62
-  Super Mario Land 2: 20
-  Super Mario World: 20
-  Super Metroid: 40
-  Terraria: 30
-  The Legend of Zelda: 20
+  Factorio: 19
+  Faxanadu: 3
+  Final Fantasy Mystic Quest: 16
+  Heretic: 3
+  Hollow Knight: 100
+  Hylics 2: 2
+  Inscryption: 24
+  'Jak and Daxter: The Precursor Legacy': 30
+  Kingdom Hearts: 30
+  Kingdom Hearts 2: 43
+  Kirby's Dream Land 3: 8
+  Landstalker - The Treasures of King Nole: 3
+  Lingo: 24
+  Links Awakening DX: 32
+  Lufia II Ancient Cave: 4
+  Mario & Luigi Superstar Saga: 29
+  MegaMan Battle Network 3: 8
+  Mega Man 2: 10
+  Mega Man 3: 10
+  Meritous: 2
+  Muse Dash: 34
+  Noita: 6
+  Ocarina of Time: 63
+  Overcooked! 2: 21
+  Paint: 32
+  Pokemon Emerald: 82
+  Pokemon Red and Blue: 33
+  Raft: 6
+  Risk of Rain 2: 40
+  SMZ3: 18
+  Satisfactory: 33
+  Saving Princess: 2
+  Secret of Evermore: 4
+  shapez: 23
+  Shivers: 4
+  Sonic Adventure 2 Battle: 32
+  Starcraft 2: 53
+  Stardew Valley: 76
+  Subnautica: 18
+  Super Mario 64: 55
+  Super Mario Land 2: 13
+  Super Mario World: 26
+  Super Metroid: 26
+  Terraria: 42
+  The Legend of Zelda: 18
   The Messenger: 10
-  The Wind Waker: 45
-  The Witness: 37
-  Timespinner: 30
-  TUNIC: 45
-  Undertale: 25
-  VVVVVV: 10
-  Wargroove: 6
+  The Wind Waker: 32
+  The Witness: 40
+  Timespinner: 25
+  TUNIC: 46
+  Undertale: 26
+  VVVVVV: 11
+  Wargroove: 4
   Yacht Dice: 40
-  Yoshi's Island: 10
-  Yu-Gi-Oh! 2006: 8
+  Yoshi's Island: 7
+  Yu-Gi-Oh! 2006: 6
   Zillion: 2
 
   
-  Banjo-Tooie: 20
-  Brotato: 6
+  Banjo-Tooie: 24
+  Brotato: 8
   Candy Box 2: 12
-  CrossCode: 10
-  Dark Cloud 1: 8
-  Donkey Kong 64: 20
+  CrossCode: 23
+  Dark Cloud 1: 21
+  Donkey Kong 64: 32
   Donkey Kong Country 2: 10
-  Donkey Kong Country: 10
-  Dragon Warrior: 8
+  Donkey Kong Country: 11
+  Dragon Warrior: 7
   Factorio - Space Age Without Space: 10
   Final Fantasy Tactics Ivalice Island: 6
-  Frogmonster: 5  
+  Frogmonster: 2
   Garfield Kart - Furious Racing: 5
-  Gauntlet Legends: 4
-  Golden Sun The Lost Age: 6
-  Luigi's Mansion: 35  
-  Mario Kart Double Dash: 15
+  Gauntlet Legends: 10
+  Golden Sun The Lost Age: 15
+  Luigi's Mansion: 34
+  Mario Kart Double Dash: 28
   Mega Man X: 15
-  Mega Man X2: 15
-  Mega Man X3: 15
-  Nine Sols: 20
-  Outer Wilds: 30
-  Ori and the Blind Forest: 15  
-  Peggle Deluxe: 15
-  Peggle Nights: 8
-  Pokemon Black and White: 25
-  Pokemon Crystal: 25
-  Pokemon Ranger (Quest): 8
+  Mega Man X2: 14
+  Mega Man X3: 14
+  Nine Sols: 25
+  Outer Wilds: 81
+  Ori and the Blind Forest: 26
+  Peggle Deluxe: 21
+  Peggle Nights: 10
+  Pokemon Black and White: 47
+  Pokemon Crystal: 40
+  Pokemon Ranger (Quest): 7
   Rain World: 10
-  Slay the Spire: 15
-  "SMW: Spicy Mycena Waffles": 20
-  Sonic Adventure DX: 25  
-  The Legend of Zelda - Oracle of Seasons: 12
-  Zork Grand Inquisitor: 5
+  Slay the Spire: 31
+  "SMW: Spicy Mycena Waffles": 23
+  Sonic Adventure DX: 22
+  The Legend of Zelda - Oracle of Seasons: 17
+  Zork Grand Inquisitor: 2


### PR DESCRIPTION
Adjusted all weights based on statistics of apparent demand of slots.

NOTES
Rules I made for these adjustments:
- Weight floor is 2. 
- Weight ceiling is 100.
- Yacht Dice stays at 40.
- Checksfinder stays at 15. 
- The weight difference for new games to the big async are halved. (should help hamper new game bias massively swinging weights)

I've figured out how to go about compiling the data I collect so hopefully next time it's easier for me. Need some way to automatically capture the data regularly, instead of just making a copy of the sheet after I get home from work.