### PR TITLE
[Peggle Deluxe, Peggle Nights] Make options considerably more random, local macguffins

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -1259,14 +1259,20 @@ Peggle Deluxe:
     - Locations
     - Name
     - Goal
+    - Master Count
+    - Level Count
     - Include Full Clears
+    - Maximum Starting Ball Count
     - Useful Item Percentage
 Peggle Nights:
     - Peggle Nights
     - Locations
     - Name
     - Goal
+    - Master Count
+    - Level Count
     - Include Full Clears
+    - Maximum Starting Ball Count
     - Useful Item Percentage
 Pokemon Black and White:
     - Pokemon Black and White

--- a/games/Peggle Deluxe.yaml
+++ b/games/Peggle Deluxe.yaml
@@ -23,7 +23,11 @@
     Tula: true
     Warren: true
   master_count:
+    1: 1
     3: 1
+    5: 1
+    8: 1
+    10: 1
   level_selection:
     1-1 Peggleland: true
     1-2 Slip and Slide: true
@@ -81,7 +85,11 @@
     9-4 9 Luft Balloons: true
     9-5 Twisted Sisters: true
   level_count:
-    35: 1
+    20: 2
+    25: 2
+    35: 3
+    40: 2
+    50: 1
   include_full_clears:
     'false': 1
     'true': 1
@@ -90,7 +98,10 @@
   target_score_requirement_percentage:
     125: 1
   maximum_starting_ball_count:
-    15: 1
+    10: 1
+    12: 1
+    15: 2
+    20: 1
   useful_item_percentage:
     random-range-40-70: 1
   useful_item_weights:
@@ -98,6 +109,7 @@
     Full Clear Discount: 3
     Score Multiplier: 2
     Target Score Discount: 1
+  local_items: Gold Peg
   triggers:
   - option_category: null
     option_name: name
@@ -105,3 +117,10 @@
     options:
       null:
         name: PeggleDX-{player}
+  # This has no effect on the slot, but makes the options sheet less confusing
+  - option_category: Peggle Deluxe
+    option_name: master_count
+    option_result: 1
+    options:
+      Peggle Deluxe:
+        master_selection_mode: single_master

--- a/games/Peggle Nights.yaml
+++ b/games/Peggle Nights.yaml
@@ -26,7 +26,11 @@
     Tula: true
     Warren: true
   master_count:
+    1: 1
     3: 1
+    5: 1
+    8: 1
+    11: 1
   level_selection:
     1-1 Crimewave: true
     1-2 Call For Help: true
@@ -99,7 +103,11 @@
     9-4 I Love Carats: true
     9-5 Great Ball of Ire: true
   level_count:
-    35: 1
+    20: 2
+    25: 2
+    35: 3
+    40: 2
+    50: 1
   include_full_clears:
     'false': 1
     'true': 1
@@ -108,7 +116,10 @@
   target_score_requirement_percentage:
     125: 1
   maximum_starting_ball_count:
-    15: 1
+    10: 1
+    12: 1
+    15: 2
+    20: 1
   useful_item_percentage:
     random-range-40-70: 1
   useful_item_weights:
@@ -116,6 +127,7 @@
     Full Clear Discount: 3
     Score Multiplier: 2
     Target Score Discount: 1
+  local_items: Shadow Peg
   triggers:
   - option_category: null
     option_name: name
@@ -123,3 +135,10 @@
     options:
       null:
         name: PeggleNight-{player}
+  # This has no effect on the slot, but makes the options sheet less confusing
+  - option_category: Peggle Nights
+    option_name: master_count
+    option_result: 1
+    options:
+      Peggle Nights:
+        master_selection_mode: single_master


### PR DESCRIPTION
This pull request:
- makes gold/shadow pegs local, as they are solely used to goal
- makes `master_count` roll either 1, 3, 5, 8, or all of them
- makes `level_count` roll 20, 25, 35, 40, or 50 levels, with a greater chance for 35 and a lower chance for 50
- makes `maximum_starting_ball_count` roll 10, 12, 15, or 20, with a greater chance for 15

~~Note: The options whitelist will need to be altered to account for these changes.~~ This PR now does this.