### PR TITLE
Tooie yaml overhaul

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -115,20 +115,27 @@ Banjo-Tooie:
     - Banjo-Tooie
     - Locations
     - Name
+    - Logic Type
     - Victory Condition
     - Open HAG 1
     - Minigame Hunt Length
     - Boss Hunt Length
     - Jinjo Family Rescue Length
+    - "Token Hunt: Mumbo Tokens in Pool"
     - Token Hunt Length
     - World Requirements
-    - Randomize Banjo-Tooie Movelist
+    - Skip Puzzles
     - Randomize Banjo-Kazooie Movelist
+    - Randomize Banjo-Tooie Movelist
+    - Jamjars' Silo Costs
     - Egg Behaviour
     - Progressive Beak Buster
+    - Progressive Shoes
     - Progressive Water Training
     - Progressive Flight
     - Progressive Egg Aim
+    - Progressive Bash Attack
+    - Randomize Note Nests
     - Randomize Treble Clefs
     - Additional Treble Clefs
     - Number of Bass Clefs
@@ -151,19 +158,21 @@ Banjo-Tooie:
     - Randomize Warp Pads
     - Randomize Silos
     - Open Silos
-    - Skip Puzzles
     - Randomize World Order
     - Randomize World Entrances
+    - Randomize Bosses
     - Open Backdoors
     - Open GI Frontdoor
     - Signpost Hints
     - Signpost Move Hints
+    - Hint Clarity
     - Add Signpost Hints to Archipelago Hints
-    - Extra Cheats
+    - Easy Canary Mary
     - Speed Up Minigames
     - Tower of Tragedy Quiz
     - Skip Klungo
     - Automatic Cheat Activation
+    - Extra Cheats
     - King Jingaling Jiggy
     - Replace Extra Jiggies
     - Replace Extra Notes with filler
@@ -180,6 +189,7 @@ Banjo-Tooie:
     - Squish Trap Weight
     - Tip Trap Weight
     - Max Traps
+    - Dialog Character
 Blasphemous:
     - Blasphemous
     - Locations

--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -135,7 +135,6 @@ Banjo-Tooie:
     - Progressive Flight
     - Progressive Egg Aim
     - Progressive Bash Attack
-    - Randomize Note Nests
     - Randomize Treble Clefs
     - Additional Treble Clefs
     - Number of Bass Clefs
@@ -167,7 +166,6 @@ Banjo-Tooie:
     - Signpost Move Hints
     - Hint Clarity
     - Add Signpost Hints to Archipelago Hints
-    - Easy Canary Mary
     - Speed Up Minigames
     - Tower of Tragedy Quiz
     - Skip Klungo

--- a/games/Banjo-Tooie.yaml
+++ b/games/Banjo-Tooie.yaml
@@ -80,7 +80,7 @@
   randomize_chuffy: random
   randomize_warp_pads: random
   randomize_silos: random
-  open_silos: 
+  open_silos:
     0: 50
     random-range-2-7: 50
   randomize_boss_loading_zones: random
@@ -265,6 +265,7 @@
         Banjo-Tooie:
           egg_behaviour: random
           progressive_beak_buster: random
+          progressive_shoes: random
           progressive_water_training: random
           progressive_flight: random
           progressive_egg_aiming: random
@@ -276,6 +277,7 @@
         Banjo-Tooie:
           egg_behaviour: random
           progressive_beak_buster: random
+          progressive_shoes: random
           progressive_water_training: random
           progressive_flight: random
           progressive_egg_aiming: random

--- a/games/Banjo-Tooie.yaml
+++ b/games/Banjo-Tooie.yaml
@@ -1,170 +1,110 @@
 ﻿Banjo-Tooie:
-  logic_type: easy_tricks
+  progression_balancing: 0 # Disabled for big asyncs
+  accessibility:
+    full: 50
+    minimal: 50 # For cryptic hint users, can be good to rule out sections of the game that don't need to be done.
 
-  victory_condition:
-    hag1: 50
-    minigame_hunt: 50
-    boss_hunt: 50
-    jinjo_family_rescue: 50
-    wonderwing_challenge: 50
-    token_hunt: 50
-    boss_hunt_and_hag1: 50
+  # Trigger value for logic type.
+  # Intended logic is notoriously restrictive with the options that can be rolled with it, so we need a trigger for this.
+  logic_type_trigger:
+    intended_no_bk: 15
+    intended_no_world: 15
+    easy_tricks: 40
+    hard_tricks: 20
+    glitches: 10
 
-  open_hag1:
-    'false': 50
-    'true': 50
+  #McGuffins, and and all trap types except Squish Trap, because starting a session with Stompadon that tries to kill you is still funny.
+  local_items: [Mumbo Token, Golden Egg Nest, Trip Trap, Slip Trap, Transform Trap, Tip Trap]
 
-  minigame_hunt_length: random-range-8-15
+  victory_condition: random
+  open_hag1: random
+  minigame_hunt_length: random-range-10-15
   boss_hunt_length: random-range-5-8
-  jinjo_family_rescue_length: random-range-4-9
-  tokens_in_pool: 15 # Triggers for nestsanity
-  token_hunt_length: random-range-10-15
-  local_items: [Mumbo Token]
+  jinjo_family_rescue_length: random-range-3-9 # 3 jinjo families can still be long.
+  tokens_in_pool: 15 # Can be overwritten by nestsanity trigger
+  token_hunt_length: random-range-10-15 # Can be overwritten by nestsanity trigger
 
-  world_requirements:
-    randomize: 50
-    normal: 50
-    quick: 50
-    long: 50
+  # If puzzles are not skipped, world costs are vanilla, and worlds order is not randomised.
+  world_requirements_trigger:
+    no_skip: 10
+    quick: 20
+    normal: 20
+    long: 20
+    randomize: 20
 
-  # Trigger value
-  randomize_moves:
-    vanilla: 20
-    bk: 50
-    bt: 50
-    bkbt: 50
-  randomize_bk_moves: none
-  randomize_bt_moves: false
+  # Overwritten by MANY triggers to false.
+  randomize_worlds: random
 
-  jamjars_silo_costs: # Triggers
-    vanilla: 50
+  # Progressive moves are dependant on BK and/or BT moves being randomised.
+  # This value can be overwritten by the logic trigger to exclude bk all when intendednobk is chosen.
+  move_rando_trigger:
+    vanilla: 10
+    bkmcjiggy: 18
+    bkall: 18
+    bt: 18
+    bkmcjiggybt: 18
+    bkallbt: 18
 
-  # These all have default values for when bkbt doesn't get rolled. triggers for bkbt moves
+  jamjars_silo_costs: vanilla # Overwritten by move_rando_trigger trigger.
+
+  # All the options in this section are overwritten by the move_rando_trigger trigger.
   egg_behaviour: start_with_blue_eggs
-  progressive_beak_buster: false
-  progressive_shoes: false
+  progressive_beak_buster: 'false'
+  progressive_shoes: 'false'
   progressive_water_training: none
-  progressive_flight: false
+  progressive_flight: 'false'
   progressive_egg_aiming: none
   progressive_bash_attack: 'false'
 
-  randomize_notes: true
-
-  randomize_treble:
-    'false': 50
-    'true': 50
-
+  # The only randomisation option always forced true in the Banjo-Tooie yaml. Randos with vanilla notes tend to feel like a solo seed.
+  randomize_notes: 'true'
+  randomize_treble: random
   extra_trebleclefs_count: random
   bass_clef_amount: random
+  randomize_jinjos: random
+  randomize_doubloons: random
+  randomize_cheato: random
+  cheato_rewards: random
+  randomize_honeycombs: random
+  honeyb_rewards: random
+  randomize_tickets: random
+  randomize_green_relics: random
+  randomize_beans: random
+  randomize_glowbos: random
+  randomize_dino_roar: random
+  nestsanity: random
+  randomize_signposts: random
+  randomize_stop_n_swap: 'false' # Override in triggers when moves get randomised.
 
-  randomize_jinjos:
-    'false': 50
-    'true': 50
-  randomize_doubloons:
-    'false': 50
-    'true': 50
-  randomize_cheato:
-    'false': 50
-    'true': 50
-  cheato_rewards:
-    'false': 50
-    'true': 50
-  randomize_honeycombs:
-    'false': 50
-    'true': 50
-  honeyb_rewards:
-    'false': 50
-    'true': 50
-  randomize_tickets:
-    'false': 50
-    'true': 50
-  randomize_green_relics:
-    'false': 50
-    'true': 50
-  randomize_beans:
-    'false': 50
-    'true': 50
-  randomize_glowbos:
-    'false': 50
-    'true': 50
-  randomize_stop_n_swap:
-    'false': 50
-    'true': 50
-  randomize_dino_roar:
-    'false': 50
-    'true': 50
-  nestsanity:
-    'false': 50
-    'true': 50
-  randomize_signposts:
-    'false': 50
-    'true': 50
+  randomize_stations: random
+  randomize_chuffy: random
+  randomize_warp_pads: random
+  randomize_silos: random
+  open_silos: 
+    0: 50
+    random-range-2-7: 50
+  randomize_boss_loading_zones: random
+  backdoors: random
+  open_gi_frontdoor: random
 
-  randomize_stations:
-    'false': 50
-    'true': 50
-  randomize_chuffy:
-    'false': 50
-    'true': 50
-  randomize_warp_pads:
-    'false': 50
-    'true': 50
-  randomize_silos:
-    'false': 50
-    'true': 50
-  open_silos: random-range-2-4 # Many combinations of options require at least 2 silos. Keep it a minimum of 2.
-  skip_puzzles: true # Since triggers can't verify multiple options as once, it's easier to leave this option true.
-
-  randomize_worlds:
-    'false': 50
-    'true': 50
-  randomize_world_entrance_loading_zones: false # Triggers for if BT moves are randomised.
-  randomize_boss_loading_zones: false # Until a big rewrite is made, it's not advised to randomise boss loading zones with random options.
-  backdoors:
-    'false': 50
-    'true': 50
-  open_gi_frontdoor:
-    'false': 50
-    'true': 50
   signpost_hints: random
   signpost_move_hints: random
-  hint_clarity: clear # I don't think cryptic hint are that enjoyable in an async. From testing, cryptic fast enough to gen that they could be done in a big async, if there's a demand for it.
-  add_signpost_hints_to_ap:
-    never: 50
-    progression: 50
-    always: 50
+  hint_clarity: random
+  add_signpost_hints_to_ap: progression
 
-  easy_canary: true
-  speed_up_minigames:
-    'true': 50
-    'false': 50
-  tower_of_tragedy:
-    skip: 50
-    round_3: 50
-    full: 50
-  skip_klungo:
-    'false': 50
-    'true': 50
-  auto_enable_cheats:
-    'false': 50
-    'true': 50
-  extra_cheats:
-    'false': 50
-    'true': 50
-  jingaling_jiggy:
-    'false': 50
-    'true': 50
-  replace_extra_jiggies:
-    'false': 50
-    'true': 50
-  replace_extra_notes:
-    'false': 50
-    'true': 50
+  easy_canary: 'true' # Most people cannot beat default Canary Mary.
+  speed_up_minigames: random
+  tower_of_tragedy: random
+  skip_klungo: random
+  auto_enable_cheats: random
+  extra_cheats: random
+  jingaling_jiggy: random
 
+  replace_extra_jiggies: random
+  replace_extra_notes: random
   extra_jiggies_weight: random
   extra_notes_weight: random
   extra_doubloons_weight: random
-
   egg_nests_weight: random
   feather_nests_weight: random
   big_o_pants_weight: random
@@ -174,99 +114,216 @@
   transform_trap_weight: random
   squish_trap_weight: random
   tip_trap_weight: random
-  max_traps: random-range-0-20
+  max_traps: 100 # Is this enough?
 
-  dialog_character: complete_random
+  dialog_character: random
 
   # If you want to add/remove triggers, double or triple-check that the yaml still gives valid combination of options!
-  # Double-check with the Banjo-Tooie devs if unsure.
   triggers:
+    # Manage the restrictions caused by logic type.
+    - option_category: Banjo-Tooie
+      option_name: logic_type_trigger
+      option_result: intended_no_bk
+      options:
+        Banjo-Tooie:
+          logic_type: intended
+          move_rando_trigger:
+            bt: 60
+            vanilla: 40
+    - option_category: Banjo-Tooie
+      option_name: logic_type_trigger
+      option_result: intended_no_world
+      options:
+        Banjo-Tooie:
+          logic_type: intended
+          randomize_worlds: 'false'
+    - option_category: Banjo-Tooie
+      option_name: logic_type_trigger
+      option_result: easy_tricks
+      options:
+        Banjo-Tooie:
+          logic_type: easy_tricks
+    - option_category: Banjo-Tooie
+      option_name: logic_type_trigger
+      option_result: hard_tricks
+      options:
+        Banjo-Tooie:
+          logic_type: hard_tricks
+    - option_category: Banjo-Tooie
+      option_name: logic_type_trigger
+      option_result: glitches
+      options:
+        Banjo-Tooie:
+          logic_type: glitches
+
+    # Manage restrictions caused by skip_puzzle false.
+    - option_category: Banjo-Tooie
+      option_name: world_requirements_trigger
+      option_result: no_skip
+      options:
+        Banjo-Tooie:
+          skip_puzzles: 'false'
+          world_requirements: 'normal'
+          randomize_worlds: 'false'
+    - option_category: Banjo-Tooie
+      option_name: world_requirements_trigger
+      option_result: quick
+      options:
+        Banjo-Tooie:
+          skip_puzzles: 'true'
+          world_requirements: quick
+    - option_category: Banjo-Tooie
+      option_name: world_requirements_trigger
+      option_result: normal
+      options:
+        Banjo-Tooie:
+          skip_puzzles: 'true'
+          world_requirements: normal
+    - option_category: Banjo-Tooie
+      option_name: world_requirements_trigger
+      option_result: long
+      options:
+        Banjo-Tooie:
+          skip_puzzles: 'true'
+          world_requirements: long
+    - option_category: Banjo-Tooie
+      option_name: world_requirements_trigger
+      option_result: randomize
+      options:
+        Banjo-Tooie:
+          skip_puzzles: 'true'
+          world_requirements: randomize
+
+    # Apply move randomisation options based on triggers.
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: vanilla
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: 'none'
+          randomize_bt_moves: 'false'
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkmcjiggy
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: mcjiggy_special
+          randomize_bt_moves: 'false'
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkall
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: 'all'
+          randomize_bt_moves: 'false'
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bt
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: 'none'
+          randomize_bt_moves: 'true'
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkmcjiggybt
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: mcjiggy_special
+          randomize_bt_moves: 'true'
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkallbt
+      options:
+        Banjo-Tooie:
+          randomize_bk_moves: 'all'
+          randomize_bt_moves: 'true'
+
+    # Set progressive move options based on what moves are randomised.
+    - option_category: Banjo-Tooie
+      option_name: randomize_bt_moves
+      option_result: 'false'
+      options:
+        Banjo-Tooie:
+          randomize_worlds: 'false'
+          randomize_world_entrance_loading_zones: 'false'
+          jamjars_silo_costs: 'vanilla'
+    - option_category: Banjo-Tooie
+      option_name: randomize_bt_moves
+      option_result: 'true'
+      options:
+        Banjo-Tooie:
+          egg_behaviour:
+            start_with_blue_eggs: 50
+            progressive_eggs: 50
+          randomize_world_entrance_loading_zones: random
+          jamjars_silo_costs: random
+    # These next 2 triggers are the same, except checking for bk mc jiggy special, and bk moves all.
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkmcjiggybt
+      options:
+        Banjo-Tooie:
+          egg_behaviour: random
+          progressive_beak_buster: random
+          progressive_water_training: random
+          progressive_flight: random
+          progressive_egg_aiming: random
+          randomize_stop_n_swap: random
+    - option_category: Banjo-Tooie
+      option_name: move_rando_trigger
+      option_result: bkallbt
+      options:
+        Banjo-Tooie:
+          egg_behaviour: random
+          progressive_beak_buster: random
+          progressive_water_training: random
+          progressive_flight: random
+          progressive_egg_aiming: random
+          randomize_stop_n_swap: random
+
+    # Stop and Swap.
+    - option_category: Banjo-Tooie
+      option_name: randomize_stop_n_swap
+      option_result: 'true'
+      options:
+        Banjo-Tooie:
+          progressive_bash_attack: random
+
+    # Triggers that help the generation success rate.
+    - option_category: Banjo-Tooie
+      option_name: logic_type
+      option_result: intended
+      options:
+        Banjo-Tooie:
+          randomize_boss_loading_zones: 'false'
+    - option_category: Banjo-Tooie
+      option_name: randomize_bt_moves
+      option_result: 'false'
+      options:
+        Banjo-Tooie:
+          randomize_boss_loading_zones: 'false'
+    - option_category: Banjo-Tooie
+      option_name: world_requirements
+      option_result: 'randomize'
+      options:
+        Banjo-Tooie:
+          randomize_jinjos: 'true'
+
+    # Misc triggers.
+    - option_category: Banjo-Tooie
+      option_name: randomize_signposts
+      option_result: 'true'
+      options:
+        Banjo-Tooie:
+          tokens_in_pool: 60
+          token_hunt_length: random-range-40-60
     - option_category: Banjo-Tooie
       option_name: nestsanity
-      option_result: true
+      option_result: 'true'
       options:
         Banjo-Tooie:
           tokens_in_pool: 100
           token_hunt_length: random-range-60-100
-
-    - option_category: Banjo-Tooie
-      option_name: randomize_moves
-      option_result: bk
-      options:
-        Banjo-Tooie:
-          randomize_bk_moves:
-            mcjiggy_special: 50
-            all: 50
-          randomize_bt_moves: "false"
-    - option_category: Banjo-Tooie
-      option_name: randomize_moves
-      option_result: bt
-      options:
-        Banjo-Tooie:
-          randomize_bk_moves: none
-          randomize_bt_moves: "true"
-          egg_behaviour:
-            start_with_blue_eggs: 50
-            progressive_eggs: 50
-          randomize_world_entrance_loading_zones:
-            'false': 50
-            'true': 50
-    - option_category: Banjo-Tooie
-      option_name: randomize_moves
-      option_result: bkbt
-      options:
-        Banjo-Tooie:
-          randomize_bk_moves:
-            mcjiggy_special: 50
-            all: 50
-          randomize_bt_moves: "true"
-          egg_behaviour:
-            start_with_blue_eggs: 50
-            random_starting_egg: 50
-            progressive_eggs: 50
-            simple_random_starting_egg: 50
-          progressive_beak_buster:
-            'false': 50
-            'true': 50
-          progressive_water_training:
-            none: 50
-            basic: 50
-            advanced: 50
-          progressive_flight:
-            'false': 50
-            'true': 50
-          progressive_egg_aiming:
-            none: 50
-            basic: 50
-            advanced: 50
-          progressive_bash_attack:
-            'false': 50
-            'true': 50
-          randomize_world_entrance_loading_zones:
-            'false': 50
-            'true': 50
-    - option_category: Banjo-Tooie
-      option_name: randomize_moves
-      option_result: vanilla
-      options:
-        Banjo-Tooie:
-          randomize_bk_moves: none
-          randomize_bt_moves: "false"
-    - option_category: Banjo-Tooie
-      option_name: randomize_bt_moves
-      option_result: true
-      options:
-        Banjo-Tooie:
-          jamjars_silo_costs:
-            vanilla: 50
-            progressive: 50
-            randomized: 50
-    - option_category: Banjo-Tooie
-      option_name: randomize_stop_n_swap
-      option_result: 'false'
-      options:
-        Banjo-Tooie:
-          progressive_bash_attack: 'false'
     - option_category: null
       option_name: name
       option_result: Player{player}

--- a/games/Banjo-Tooie.yaml
+++ b/games/Banjo-Tooie.yaml
@@ -114,7 +114,7 @@
   transform_trap_weight: random
   squish_trap_weight: random
   tip_trap_weight: random
-  max_traps: 100 # Is this enough?
+  max_traps: random-range-0-100
 
   dialog_character: random
 


### PR DESCRIPTION
Almost every option that Tooie has can be randomised now.
Among the new options: logic type, boss loading zones, puzzles not skipped, cryptic hints

Here's the time for a 1500 yaml gen.
<img width="893" height="144" alt="image" src="https://github.com/user-attachments/assets/46dde316-367f-46cc-a7d4-24b80439bd33" />
