### PR TITLE
[Hollow Knight] - Add godhome ending

### DIFF
--- a/games/Hollow Knight.yaml
+++ b/games/Hollow Knight.yaml
@@ -67,11 +67,11 @@ Hollow Knight:
   RemoveSpellUpgrades: 'false'
   StartLocation: king's_pass
   Goal:
-    siblings: 8
-    radiance: 3
-    grub_hunt: 2
-    godhome: 0
-    godhome_flower: 0
+    siblings: 55
+    radiance: 20
+    grub_hunt: 15
+    godhome: 7
+    godhome_flower: 3
   GrubHuntGoal: random-range-middle-25-35
   WhitePalace: 
     exclude: 5


### PR DESCRIPTION
We've pretty much fully phased out custom yamls and things like Satisfactory P5 and Celeste Farewell exist, so I think this is fine.

Current weights between the other goal options are roughly what they were before, godhome is 10%. If we feel this is too high I can change it, but I've made this mistake with Celeste before

Only thing I'm uncertain of is whether your skip settings should influence your odds of rolling godhome. I think that there are probably some people who DONT want to do weird skips but DO want to do godhome, so I left it neutral.