### PR TITLE
KH1: Enable Warp Anywhere

### DIFF
--- a/games/Kingdom Hearts.yaml
+++ b/games/Kingdom Hearts.yaml
@@ -117,7 +117,7 @@ Kingdom Hearts:
   unlock_0_volume: false
   unskippable: true
   auto_save: true
-  warp_anywhere: false
+  warp_anywhere: true
   local_items: []
   start_hints: []
 


### PR DESCRIPTION
Warp Anywhere lets players input a button combo to open up a menu they can save/exit levels from.
Having this on helps players escape from possible softlocks and is mostly a power user feature otherwise that won't affect players who don't know about it.