### PR TITLE
[Satisfactory] Added Manufacturer as Local Item

### DIFF
--- a/games/Satisfactory.yaml
+++ b/games/Satisfactory.yaml
@@ -84,6 +84,8 @@ Satisfactory:
     harder: 20
   trap_selection_override:
     []
+  local_items:
+    - "Building: Manufacturer"
   triggers:
 # Disables side goals for Phase 2
     - option_category: Satisfactory


### PR DESCRIPTION
The aim is to have manufacturers local in Satisfactory to allow players to prepare pre-requisite items they can produce if they are missing a space elevator/item recipe that they would need to progress.

Without the manufacturer, the player is bottlenecked to early-game items. Anything beyond Phase 2 near impossible as a player would need a manufacturer to craft required items with three or four materials. If the manufacturer gets flung deep into the multiworld, this could limit the player to grind and idle from the start of Phase 3 to the goal at Phase 4 or 5. There is also milestone quantities (which can broadly be described as bundles of mid-game items with up to thousands of units per item in the bundle) and the general factory automation. I would also be more worried about this with #428 potentially increasing the weights of Phase 4 & 5 space elevator goals.

Edit: Updated comment to focus on the manufacturers. Might have confused a wait for a recipe for a wait for assemblers. 
