### PR TITLE
[Nine Sols] Shop Rando/Root Node rando and logic difficulty weight adjustment

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -1158,6 +1158,7 @@ Nine Sols:
     - Locations
     - Name
     - Logic Difficulty
+    - Shuffle Sol Seals
     - Seals For Eigong
     - randomize_shops
     - Skip Soulscape Platforming

--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -1157,11 +1157,13 @@ Nine Sols:
     - Nine Sols
     - Locations
     - Name
+    - Logic Difficulty
     - Seals For Eigong
-    - Shuffle Sol Seals
+    - randomize_shops
     - Skip Soulscape Platforming
     - Jade Cost Maximum
     - First Root Node
+    - shuffle_some_root_nodes
     - Shuffle Wall Climb
 Noita:
     - Noita

--- a/games/Nine Sols.yaml
+++ b/games/Nine Sols.yaml
@@ -14,6 +14,12 @@ Nine Sols:
   shop_unlocks:
     sol_seals: 1
     unlock_items: 1
+  kuafu_shop_unlock_sol_seals: random-range-1-2
+  chiyou_shop_unlock_sol_seals: random-range-3-4
+  kuafu_extra_inventory_unlock_sol_seals: random-range-5-7
+  randomize_shops:
+    true: 1
+    false: 1
   first_root_node:
     apeman_facility_monitoring: 1
     grotto_of_scriptures_entry: 1
@@ -21,11 +27,14 @@ Nine Sols:
     factory_great_hall: 1
     lake_yaochi_ruins: 1
     power_reservoir_east: 1
+  shuffle_some_root_nodes:
+    true: 1
+    false: 1
   shuffle_grapple: true
   shuffle_wall_climb: random
   shuffle_ledge_grab: false
   logic_difficulty:
-    vanilla: 3
+    vanilla: 2
     medium: 1
   local_items:
    - "Sol Seals"


### PR DESCRIPTION
These two options have been out for a while now and have shown no issues with logic for multiple months. This sets both of those options to 50/50s. It also changes the vanilla:medium logic ratio from 3:1 to 2:1 as tricks in that logic difficulty are not very challenging to learn.