### PR TITLE
[Terraria] Remove Calamity

### DIFF
--- a/async_sheet_tools/gameoption_whitelist.yaml
+++ b/async_sheet_tools/gameoption_whitelist.yaml
@@ -2126,7 +2126,6 @@ Terraria:
     - Terraria
     - Locations
     - Name
-    - Calamity Mod Integration
     - Goal
     - Early Pre-Hardmode Achievements
     - Normal Achievements

--- a/games/Terraria.yaml
+++ b/games/Terraria.yaml
@@ -1,8 +1,7 @@
 ﻿Terraria: 
   # Calamity is a mod for Terraria that adds many more bosses to the game.
-  # Sorry, I was wrong. Calamity is actually in much higher demand than I thought.
   calamity:
-    'false': 1
+    'false': 4
     'true': 1
   # This is a very difficult secret seed in vanilla. It's probably too hard for a big async yaml.
   getfixedboi: 'false'

--- a/games/Terraria.yaml
+++ b/games/Terraria.yaml
@@ -1,11 +1,8 @@
 ﻿Terraria: 
-  # Calamity is a mod for Terraria that adds many more bosses to the game.
-  calamity:
-    'false': 4
-    'true': 1
+  # Calamity has been disabled due to concerns regarding recent events.
+  calamity: 'false'
   # This is a very difficult secret seed in vanilla. It's probably too hard for a big async yaml.
   getfixedboi: 'false'
-  # Overridden via triggers if calamity is rolled
   goal:
     golem: 1
     moon_lord: 3
@@ -28,19 +25,7 @@
   death_link: 'false'
   # This is an awful location to check. If 200 fishing quests is considered "too grindy" for the big async, this isn't really any better.
   exclude_locations: And Good Riddance!
-  triggers:
-    # Calamity is longer than vanilla, with bosses that go past vanilla progression. This forces the goal to require defeating Post-Moon Lord bosses.
-    # Zenith is still a valid goal here, as Calamity changes its crafting recipe to require Yharon to be defeated.
-    - option_category: Terraria
-      option_name: calamity
-      option_result: 'true'
-      options:
-        Terraria:
-          goal:
-            yharon_dragon_of_rebirth: 1
-            zenith: 2
-            calamity_final_bosses: 3
-    
+  triggers:    
     # It doesn't make sense to have early or grindy achievements if normal achievements are disabled anyway.
     # This is identical to how it worked before.
     - option_category: Terraria


### PR DESCRIPTION
Due to recent Calamity drama (which I will not explain here), I get the feeling that not as many people are going to want to play Calamity in the next big async. ~~This pull request reduces its weight from 50% to 20%. I have opted to not turn off Calamity entirely in the event that there are still people that want to play it. This weight change may be overkill, or perhaps it's not enough; it should probably be discussed in the post-async thread before merging this.~~

Update 2026-08-10:
This pull request now prevents Calamity from rolling completely.